### PR TITLE
Transfer repo and rename to kubevirt-ipam-controller

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -29,7 +29,7 @@ jobs:
     - name: Ensure latest install manifest
       run: |
         echo "" > dist/install.yaml
-        IMG=ghcr.io/maiqueb/kubevirt-ipam-claims:latest make build-installer
+        IMG=ghcr.io/kubevirt/ipam-controller:latest make build-installer
         if [[ -n "$(git status --porcelain)" ]]; then
           echo "Please run 'make build-installer' and commit those changes"
           git status --porcelain

--- a/.github/workflows/publish-img.yaml
+++ b/.github/workflows/publish-img.yaml
@@ -7,7 +7,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
+  IMAGE_NAME: kubevirt/ipam-controller
 
 jobs:
   push-amd64:
@@ -32,20 +32,20 @@ jobs:
         uses: docker/setup-buildx-action@v3.0.0
 
       - name: Login to Container Registry
-        if: github.repository_owner == 'maiqueb'
+        if: github.repository_owner == 'kubevirt'
         uses: docker/login-action@v3.0.0
         with:
-          registry: ghcr.io
+          registry: ${{ env.REGISTRY }}
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Push latest container image
-        if: github.repository_owner == 'maiqueb'
+        if: github.repository_owner == 'kubevirt'
         uses: docker/build-push-action@v5.3.0
         with:
           context: .
           push: true
-          tags: ghcr.io/${{ github.repository }}:latest
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
           file: Dockerfile
 
       - name: Push stable container image
@@ -54,12 +54,12 @@ jobs:
         with:
           context: .
           push: true
-          tags: ghcr.io/${{ github.repository }}:${{ github.ref_name }}
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}
           file: Dockerfile
 
       - name: Template release manifests
         if: startsWith(github.ref, 'refs/tags/')
-        run: IMG=ghcr.io/${{ github.repository }}:${{ github.ref_name }} make build-installer
+        run: IMG=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }} make build-installer
 
       - name: Release the kraken
         uses: softprops/action-gh-release@v1

--- a/PROJECT
+++ b/PROJECT
@@ -2,9 +2,9 @@
 # This file is used to track the info used to scaffold your project
 # and allow the plugins properly work.
 # More info: https://book.kubebuilder.io/reference/project-config.html
-domain: github.com/maiqueb
+domain: github.com/kubevirt
 layout:
 - go.kubebuilder.io/v4
-projectName: kubevirt-ipam-claims
-repo: github.com/maiqueb/kubevirt-ipam-claims
+projectName: kubevirt-ipam-controller
+repo: github.com/kubevirt/ipam-extensions
 version: "3"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# kubevirt-ipam-claims
+# kubevirt-ipam-controller
 This repo provide a KubeVirt extension to create (and manage the lifecycle of)
 `IPAMClaim`s on behalf of KubeVirt virtual machines.
 
@@ -33,7 +33,7 @@ that implements this IPAM multi-network standard.
 **Build and push your image to the location specified by `IMG`:**
 
 ```sh
-make docker-build docker-push IMG=<some-registry>/kubevirt-ipam-claims:<tag>
+make docker-build docker-push IMG=<some-registry>/ipam-controller:<tag>
 ```
 
 **NOTE:** This image ought to be published in the personal registry you specified. 
@@ -43,7 +43,7 @@ Make sure you have the proper permission to the registry if the above commands d
 **Deploy the Manager to the cluster with the image specified by `IMG`:**
 
 ```sh
-make deploy IMG=<some-registry>/kubevirt-ipam-claims:<tag>
+make deploy IMG=<some-registry>/ipam-controller:<tag>
 ```
 
 > **NOTE**: If you encounter RBAC errors, you may need to grant yourself cluster-admin 
@@ -62,7 +62,7 @@ Following are the steps to build the installer and distribute this project to us
 1. Build the installer for the image built and published in the registry:
 
 ```sh
-make build-installer IMG=<some-registry>/kubevirt-ipam-claims:<tag>
+make build-installer IMG=<some-registry>/ipam-controller:<tag>
 ```
 
 NOTE: The makefile target mentioned above generates an 'install.yaml'
@@ -75,7 +75,7 @@ its dependencies.
 Users can just run kubectl apply -f <URL for YAML BUNDLE> to install the project, i.e.:
 
 ```sh
-kubectl apply -f https://raw.githubusercontent.com/maiqueb/kubevirt-ipam-claims/main/dist/install.yaml
+kubectl apply -f https://raw.githubusercontent.com/kubevirt/ipam-extensions/main/dist/install.yaml
 ```
 
 ## Requesting persistent IPs for KubeVirt VMs

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -44,8 +44,8 @@ import (
 	ipamclaimsapi "github.com/k8snetworkplumbingwg/ipamclaims/pkg/crd/ipamclaims/v1alpha1"
 	nadv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 
-	"github.com/maiqueb/kubevirt-ipam-claims/pkg/ipamclaimswebhook"
-	"github.com/maiqueb/kubevirt-ipam-claims/pkg/vmnetworkscontroller"
+	"github.com/kubevirt/ipam-extensions/pkg/ipamclaimswebhook"
+	"github.com/kubevirt/ipam-extensions/pkg/vmnetworkscontroller"
 	//+kubebuilder:scaffold:imports
 )
 

--- a/config/certmanager/certificate.yaml
+++ b/config/certmanager/certificate.yaml
@@ -8,11 +8,11 @@ metadata:
     app.kubernetes.io/name: certificate
     app.kubernetes.io/instance: serving-cert
     app.kubernetes.io/component: certificate
-    app.kubernetes.io/created-by: kubevirt-ipam-claims
-    app.kubernetes.io/part-of: kubevirt-ipam-claims
+    app.kubernetes.io/created-by: kubevirt-ipam-controller
+    app.kubernetes.io/part-of: kubevirt-ipam-controller
     app.kubernetes.io/managed-by: kustomize
   name: selfsigned-issuer
-  namespace: kubevirt-ipam-claims-system
+  namespace: kubevirt-ipam-controller-system
 spec:
   selfSigned: {}
 ---
@@ -23,11 +23,11 @@ metadata:
     app.kubernetes.io/name: certificate
     app.kubernetes.io/instance: serving-cert
     app.kubernetes.io/component: certificate
-    app.kubernetes.io/created-by: kubevirt-ipam-claims
-    app.kubernetes.io/part-of: kubevirt-ipam-claims
+    app.kubernetes.io/created-by: kubevirt-ipam-controller
+    app.kubernetes.io/part-of: kubevirt-ipam-controller
     app.kubernetes.io/managed-by: kustomize
   name: serving-cert  # this name should match the one appeared in kustomizeconfig.yaml
-  namespace: kubevirt-ipam-claims-system
+  namespace: kubevirt-ipam-controller-system
 spec:
   # SERVICE_NAME and SERVICE_NAMESPACE will be substituted by kustomize
   dnsNames:

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -1,12 +1,12 @@
 # Adds namespace to all resources.
-namespace: kubevirt-ipam-claims-system
+namespace: kubevirt-ipam-controller-system
 
 # Value of this field is prepended to the
 # names of all resources, e.g. a deployment named
 # "wordpress" becomes "alices-wordpress".
 # Note that it should also match with the prefix (text before '-') of the namespace
 # field above.
-namePrefix: kubevirt-ipam-claims-
+namePrefix: kubevirt-ipam-controller-
 
 labels:
 - includeSelectors: true

--- a/config/default/manager_config_patch.yaml
+++ b/config/default/manager_config_patch.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: controller-manager
+  name: manager
   namespace: system
 spec:
   template:

--- a/config/default/manager_webhook_patch.yaml
+++ b/config/default/manager_webhook_patch.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: controller-manager
+  name: manager
   namespace: system
 spec:
   template:

--- a/config/default/webhookcainjection_patch.yaml
+++ b/config/default/webhookcainjection_patch.yaml
@@ -7,10 +7,10 @@ metadata:
     app.kubernetes.io/name: mutatingwebhookconfiguration
     app.kubernetes.io/instance: mutating-webhook-configuration
     app.kubernetes.io/component: webhook
-    app.kubernetes.io/created-by: kubevirt-ipam-claims
-    app.kubernetes.io/part-of: kubevirt-ipam-claims
+    app.kubernetes.io/created-by: kubevirt-ipam-controller
+    app.kubernetes.io/part-of: kubevirt-ipam-controller
     app.kubernetes.io/managed-by: kustomize
   name: mutating-webhook-configuration
-  namespace: kubevirt-ipam-claims-system
+  namespace: kubevirt-ipam-controller-system
   annotations:
     cert-manager.io/inject-ca-from: CERTIFICATE_NAMESPACE/CERTIFICATE_NAME

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -4,5 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: ghcr.io/maiqueb/kubevirt-ipam-claims
+  newName: ghcr.io/kubevirt/ipam-controller
   newTag: latest

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -2,39 +2,39 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
-    control-plane: controller-manager
+    control-plane: manager
     app.kubernetes.io/name: namespace
     app.kubernetes.io/instance: system
     app.kubernetes.io/component: manager
-    app.kubernetes.io/created-by: kubevirt-ipam-claims
-    app.kubernetes.io/part-of: kubevirt-ipam-claims
+    app.kubernetes.io/created-by: kubevirt-ipam-controller
+    app.kubernetes.io/part-of: kubevirt-ipam-controller
     app.kubernetes.io/managed-by: kustomize
   name: system
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: controller-manager
+  name: manager
   namespace: system
   labels:
-    control-plane: controller-manager
+    control-plane: manager
     app.kubernetes.io/name: deployment
-    app.kubernetes.io/instance: controller-manager
+    app.kubernetes.io/instance: manager
     app.kubernetes.io/component: manager
-    app.kubernetes.io/created-by: kubevirt-ipam-claims
-    app.kubernetes.io/part-of: kubevirt-ipam-claims
+    app.kubernetes.io/created-by: kubevirt-ipam-controller
+    app.kubernetes.io/part-of: kubevirt-ipam-controller
     app.kubernetes.io/managed-by: kustomize
 spec:
   selector:
     matchLabels:
-      control-plane: controller-manager
+      control-plane: manager
   replicas: 1
   template:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
-        control-plane: controller-manager
+        control-plane: manager
     spec:
       # TODO(user): Uncomment the following code to configure the nodeAffinity expression
       # according to the platforms which are supported by your solution.
@@ -91,5 +91,5 @@ spec:
           requests:
             cpu: 10m
             memory: 64Mi
-      serviceAccountName: controller-manager
+      serviceAccountName: manager
       terminationGracePeriodSeconds: 10

--- a/config/rbac/leader_election_role.yaml
+++ b/config/rbac/leader_election_role.yaml
@@ -6,8 +6,8 @@ metadata:
     app.kubernetes.io/name: role
     app.kubernetes.io/instance: leader-election-role
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: kubevirt-ipam-claims
-    app.kubernetes.io/part-of: kubevirt-ipam-claims
+    app.kubernetes.io/created-by: kubevirt-ipam-controller
+    app.kubernetes.io/part-of: kubevirt-ipam-controller
     app.kubernetes.io/managed-by: kustomize
   name: leader-election-role
 rules:

--- a/config/rbac/leader_election_role_binding.yaml
+++ b/config/rbac/leader_election_role_binding.yaml
@@ -5,8 +5,8 @@ metadata:
     app.kubernetes.io/name: rolebinding
     app.kubernetes.io/instance: leader-election-rolebinding
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: kubevirt-ipam-claims
-    app.kubernetes.io/part-of: kubevirt-ipam-claims
+    app.kubernetes.io/created-by: kubevirt-ipam-controller
+    app.kubernetes.io/part-of: kubevirt-ipam-controller
     app.kubernetes.io/managed-by: kustomize
   name: leader-election-rolebinding
 roleRef:
@@ -15,5 +15,5 @@ roleRef:
   name: leader-election-role
 subjects:
 - kind: ServiceAccount
-  name: controller-manager
+  name: manager
   namespace: system

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -5,8 +5,8 @@ metadata:
     app.kubernetes.io/name: clusterrole
     app.kubernetes.io/instance: manager-role
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: kubevirt-ipam-claims
-    app.kubernetes.io/part-of: kubevirt-ipam-claims
+    app.kubernetes.io/created-by: kubevirt-ipam-controller
+    app.kubernetes.io/part-of: kubevirt-ipam-controller
     app.kubernetes.io/managed-by: kustomize
   name: manager-role
 rules:

--- a/config/rbac/role_binding.yaml
+++ b/config/rbac/role_binding.yaml
@@ -5,8 +5,8 @@ metadata:
     app.kubernetes.io/name: clusterrolebinding
     app.kubernetes.io/instance: manager-rolebinding
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: kubevirt-ipam-claims
-    app.kubernetes.io/part-of: kubevirt-ipam-claims
+    app.kubernetes.io/created-by: kubevirt-ipam-controller
+    app.kubernetes.io/part-of: kubevirt-ipam-controller
     app.kubernetes.io/managed-by: kustomize
   name: manager-rolebinding
 roleRef:
@@ -15,5 +15,5 @@ roleRef:
   name: manager-role
 subjects:
 - kind: ServiceAccount
-  name: controller-manager
+  name: manager
   namespace: system

--- a/config/rbac/service_account.yaml
+++ b/config/rbac/service_account.yaml
@@ -3,10 +3,10 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/name: serviceaccount
-    app.kubernetes.io/instance: controller-manager-sa
+    app.kubernetes.io/instance: manager-sa
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: kubevirt-ipam-claims
-    app.kubernetes.io/part-of: kubevirt-ipam-claims
+    app.kubernetes.io/created-by: kubevirt-ipam-controller
+    app.kubernetes.io/part-of: kubevirt-ipam-controller
     app.kubernetes.io/managed-by: kustomize
-  name: controller-manager
+  name: manager
   namespace: system

--- a/config/webhook/service.yaml
+++ b/config/webhook/service.yaml
@@ -5,15 +5,15 @@ metadata:
     app.kubernetes.io/name: service
     app.kubernetes.io/instance: webhook-service
     app.kubernetes.io/component: webhook
-    app.kubernetes.io/created-by: kubevirt-ipam-claims
-    app.kubernetes.io/part-of: kubevirt-ipam-claims
+    app.kubernetes.io/created-by: kubevirt-ipam-controller
+    app.kubernetes.io/part-of: kubevirt-ipam-controller
     app.kubernetes.io/managed-by: kustomize
   name: webhook-service
-  namespace: kubevirt-ipam-claims-system
+  namespace: kubevirt-ipam-controller-system
 spec:
   ports:
     - port: 443
       protocol: TCP
       targetPort: 9443
   selector:
-    control-plane: controller-manager
+    control-plane: manager

--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -5,13 +5,13 @@ metadata:
   labels:
     app: ipam-virt-workloads
     app.kubernetes.io/component: manager
-    app.kubernetes.io/created-by: kubevirt-ipam-claims
+    app.kubernetes.io/created-by: kubevirt-ipam-controller
     app.kubernetes.io/instance: system
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/name: namespace
-    app.kubernetes.io/part-of: kubevirt-ipam-claims
-    control-plane: controller-manager
-  name: kubevirt-ipam-claims-system
+    app.kubernetes.io/part-of: kubevirt-ipam-controller
+    control-plane: manager
+  name: kubevirt-ipam-controller-system
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -19,13 +19,13 @@ metadata:
   labels:
     app: ipam-virt-workloads
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: kubevirt-ipam-claims
-    app.kubernetes.io/instance: controller-manager-sa
+    app.kubernetes.io/created-by: kubevirt-ipam-controller
+    app.kubernetes.io/instance: manager-sa
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/name: serviceaccount
-    app.kubernetes.io/part-of: kubevirt-ipam-claims
-  name: kubevirt-ipam-claims-controller-manager
-  namespace: kubevirt-ipam-claims-system
+    app.kubernetes.io/part-of: kubevirt-ipam-controller
+  name: kubevirt-ipam-controller-manager
+  namespace: kubevirt-ipam-controller-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -33,13 +33,13 @@ metadata:
   labels:
     app: ipam-virt-workloads
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: kubevirt-ipam-claims
+    app.kubernetes.io/created-by: kubevirt-ipam-controller
     app.kubernetes.io/instance: leader-election-role
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/name: role
-    app.kubernetes.io/part-of: kubevirt-ipam-claims
-  name: kubevirt-ipam-claims-leader-election-role
-  namespace: kubevirt-ipam-claims-system
+    app.kubernetes.io/part-of: kubevirt-ipam-controller
+  name: kubevirt-ipam-controller-leader-election-role
+  namespace: kubevirt-ipam-controller-system
 rules:
 - apiGroups:
   - ""
@@ -79,12 +79,12 @@ metadata:
   labels:
     app: ipam-virt-workloads
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: kubevirt-ipam-claims
+    app.kubernetes.io/created-by: kubevirt-ipam-controller
     app.kubernetes.io/instance: manager-role
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/name: clusterrole
-    app.kubernetes.io/part-of: kubevirt-ipam-claims
-  name: kubevirt-ipam-claims-manager-role
+    app.kubernetes.io/part-of: kubevirt-ipam-controller
+  name: kubevirt-ipam-controller-manager-role
 rules:
 - apiGroups:
   - ""
@@ -126,21 +126,21 @@ metadata:
   labels:
     app: ipam-virt-workloads
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: kubevirt-ipam-claims
+    app.kubernetes.io/created-by: kubevirt-ipam-controller
     app.kubernetes.io/instance: leader-election-rolebinding
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/name: rolebinding
-    app.kubernetes.io/part-of: kubevirt-ipam-claims
-  name: kubevirt-ipam-claims-leader-election-rolebinding
-  namespace: kubevirt-ipam-claims-system
+    app.kubernetes.io/part-of: kubevirt-ipam-controller
+  name: kubevirt-ipam-controller-leader-election-rolebinding
+  namespace: kubevirt-ipam-controller-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: kubevirt-ipam-claims-leader-election-role
+  name: kubevirt-ipam-controller-leader-election-role
 subjects:
 - kind: ServiceAccount
-  name: kubevirt-ipam-claims-controller-manager
-  namespace: kubevirt-ipam-claims-system
+  name: kubevirt-ipam-controller-manager
+  namespace: kubevirt-ipam-controller-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -148,20 +148,20 @@ metadata:
   labels:
     app: ipam-virt-workloads
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: kubevirt-ipam-claims
+    app.kubernetes.io/created-by: kubevirt-ipam-controller
     app.kubernetes.io/instance: manager-rolebinding
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/name: clusterrolebinding
-    app.kubernetes.io/part-of: kubevirt-ipam-claims
-  name: kubevirt-ipam-claims-manager-rolebinding
+    app.kubernetes.io/part-of: kubevirt-ipam-controller
+  name: kubevirt-ipam-controller-manager-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: kubevirt-ipam-claims-manager-role
+  name: kubevirt-ipam-controller-manager-role
 subjects:
 - kind: ServiceAccount
-  name: kubevirt-ipam-claims-controller-manager
-  namespace: kubevirt-ipam-claims-system
+  name: kubevirt-ipam-controller-manager
+  namespace: kubevirt-ipam-controller-system
 ---
 apiVersion: v1
 kind: Service
@@ -169,13 +169,13 @@ metadata:
   labels:
     app: ipam-virt-workloads
     app.kubernetes.io/component: webhook
-    app.kubernetes.io/created-by: kubevirt-ipam-claims
+    app.kubernetes.io/created-by: kubevirt-ipam-controller
     app.kubernetes.io/instance: webhook-service
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/name: service
-    app.kubernetes.io/part-of: kubevirt-ipam-claims
-  name: kubevirt-ipam-claims-webhook-service
-  namespace: kubevirt-ipam-claims-system
+    app.kubernetes.io/part-of: kubevirt-ipam-controller
+  name: kubevirt-ipam-controller-webhook-service
+  namespace: kubevirt-ipam-controller-system
 spec:
   ports:
   - port: 443
@@ -183,7 +183,7 @@ spec:
     targetPort: 9443
   selector:
     app: ipam-virt-workloads
-    control-plane: controller-manager
+    control-plane: manager
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -191,34 +191,34 @@ metadata:
   labels:
     app: ipam-virt-workloads
     app.kubernetes.io/component: manager
-    app.kubernetes.io/created-by: kubevirt-ipam-claims
-    app.kubernetes.io/instance: controller-manager
+    app.kubernetes.io/created-by: kubevirt-ipam-controller
+    app.kubernetes.io/instance: manager
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/name: deployment
-    app.kubernetes.io/part-of: kubevirt-ipam-claims
-    control-plane: controller-manager
-  name: kubevirt-ipam-claims-controller-manager
-  namespace: kubevirt-ipam-claims-system
+    app.kubernetes.io/part-of: kubevirt-ipam-controller
+    control-plane: manager
+  name: kubevirt-ipam-controller-manager
+  namespace: kubevirt-ipam-controller-system
 spec:
   replicas: 1
   selector:
     matchLabels:
       app: ipam-virt-workloads
-      control-plane: controller-manager
+      control-plane: manager
   template:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
         app: ipam-virt-workloads
-        control-plane: controller-manager
+        control-plane: manager
     spec:
       containers:
       - args:
         - --leader-elect
         command:
         - /manager
-        image: ghcr.io/maiqueb/kubevirt-ipam-claims:latest
+        image: ghcr.io/kubevirt/ipam-controller:latest
         livenessProbe:
           httpGet:
             path: /healthz
@@ -256,7 +256,7 @@ spec:
         runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
-      serviceAccountName: kubevirt-ipam-claims-controller-manager
+      serviceAccountName: kubevirt-ipam-controller-manager
       terminationGracePeriodSeconds: 10
       volumes:
       - name: cert
@@ -270,20 +270,20 @@ metadata:
   labels:
     app: ipam-virt-workloads
     app.kubernetes.io/component: certificate
-    app.kubernetes.io/created-by: kubevirt-ipam-claims
+    app.kubernetes.io/created-by: kubevirt-ipam-controller
     app.kubernetes.io/instance: serving-cert
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/name: certificate
-    app.kubernetes.io/part-of: kubevirt-ipam-claims
-  name: kubevirt-ipam-claims-serving-cert
-  namespace: kubevirt-ipam-claims-system
+    app.kubernetes.io/part-of: kubevirt-ipam-controller
+  name: kubevirt-ipam-controller-serving-cert
+  namespace: kubevirt-ipam-controller-system
 spec:
   dnsNames:
-  - kubevirt-ipam-claims-webhook-service.kubevirt-ipam-claims-system.svc
-  - kubevirt-ipam-claims-webhook-service.kubevirt-ipam-claims-system.svc.cluster.local
+  - kubevirt-ipam-controller-webhook-service.kubevirt-ipam-controller-system.svc
+  - kubevirt-ipam-controller-webhook-service.kubevirt-ipam-controller-system.svc.cluster.local
   issuerRef:
     kind: Issuer
-    name: kubevirt-ipam-claims-selfsigned-issuer
+    name: kubevirt-ipam-controller-selfsigned-issuer
   secretName: webhook-server-cert
 ---
 apiVersion: cert-manager.io/v1
@@ -292,13 +292,13 @@ metadata:
   labels:
     app: ipam-virt-workloads
     app.kubernetes.io/component: certificate
-    app.kubernetes.io/created-by: kubevirt-ipam-claims
+    app.kubernetes.io/created-by: kubevirt-ipam-controller
     app.kubernetes.io/instance: serving-cert
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/name: certificate
-    app.kubernetes.io/part-of: kubevirt-ipam-claims
-  name: kubevirt-ipam-claims-selfsigned-issuer
-  namespace: kubevirt-ipam-claims-system
+    app.kubernetes.io/part-of: kubevirt-ipam-controller
+  name: kubevirt-ipam-controller-selfsigned-issuer
+  namespace: kubevirt-ipam-controller-system
 spec:
   selfSigned: {}
 ---
@@ -306,23 +306,23 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: kubevirt-ipam-claims-system/kubevirt-ipam-claims-serving-cert
+    cert-manager.io/inject-ca-from: kubevirt-ipam-controller-system/kubevirt-ipam-controller-serving-cert
   labels:
     app: ipam-virt-workloads
     app.kubernetes.io/component: webhook
-    app.kubernetes.io/created-by: kubevirt-ipam-claims
+    app.kubernetes.io/created-by: kubevirt-ipam-controller
     app.kubernetes.io/instance: mutating-webhook-configuration
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/name: mutatingwebhookconfiguration
-    app.kubernetes.io/part-of: kubevirt-ipam-claims
-  name: kubevirt-ipam-claims-mutating-webhook-configuration
+    app.kubernetes.io/part-of: kubevirt-ipam-controller
+  name: kubevirt-ipam-controller-mutating-webhook-configuration
 webhooks:
 - admissionReviewVersions:
   - v1
   clientConfig:
     service:
-      name: kubevirt-ipam-claims-webhook-service
-      namespace: kubevirt-ipam-claims-system
+      name: kubevirt-ipam-controller-webhook-service
+      namespace: kubevirt-ipam-controller-system
       path: /mutate-v1-pod
   failurePolicy: Fail
   name: ipam-claims.k8s.cni.cncf.io

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/maiqueb/kubevirt-ipam-claims
+module github.com/kubevirt/ipam-extensions
 
 go 1.21
 

--- a/pkg/ipamclaimswebhook/podmutator.go
+++ b/pkg/ipamclaimswebhook/podmutator.go
@@ -39,7 +39,7 @@ import (
 
 	virtv1 "kubevirt.io/api/core/v1"
 
-	"github.com/maiqueb/kubevirt-ipam-claims/pkg/config"
+	"github.com/kubevirt/ipam-extensions/pkg/config"
 )
 
 // +kubebuilder:webhook:path=/mutate-v1-pod,mutating=true,failurePolicy=fail,groups="",resources=pods,verbs=create;update,versions=v1,name=ipam-claims.k8s.cni.cncf.io,admissionReviewVersions=v1,sideEffects=None

--- a/pkg/vmnetworkscontroller/controller.go
+++ b/pkg/vmnetworkscontroller/controller.go
@@ -24,7 +24,7 @@ import (
 
 	virtv1 "kubevirt.io/api/core/v1"
 
-	"github.com/maiqueb/kubevirt-ipam-claims/pkg/config"
+	"github.com/kubevirt/ipam-extensions/pkg/config"
 )
 
 const kubevirtVMFinalizer = "kubevirt.io/persistent-ipam"

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -26,7 +26,7 @@ import (
 
 	ctrl "sigs.k8s.io/controller-runtime"
 
-	testenv "github.com/maiqueb/kubevirt-ipam-claims/test/env"
+	testenv "github.com/kubevirt/ipam-extensions/test/env"
 )
 
 var _ = BeforeSuite(func() {
@@ -37,5 +37,5 @@ var _ = BeforeSuite(func() {
 // Run e2e tests using the Ginkgo runner.
 func TestE2E(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "kubevirt-ipam-claims e2e suite")
+	RunSpecs(t, "kubevirt-ipam-controller e2e suite")
 }

--- a/test/e2e/persistentips_test.go
+++ b/test/e2e/persistentips_test.go
@@ -32,7 +32,7 @@ import (
 
 	kubevirtv1 "kubevirt.io/api/core/v1"
 
-	testenv "github.com/maiqueb/kubevirt-ipam-claims/test/env"
+	testenv "github.com/kubevirt/ipam-extensions/test/env"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 

--- a/test/go.mod
+++ b/test/go.mod
@@ -1,4 +1,4 @@
-module github.com/maiqueb/kubevirt-ipam-claims/test
+module github.com/kubevirt/ipam-extensions/test
 
 go 1.22.0
 


### PR DESCRIPTION
This PR renames the org and repo
so we will adapt to the transfer under `kubevirt/ipam-extensions`.

It renames the controller to `kubevirt-ipam-controller`.

It also rename resources named `controller-manager` to `manager`
so once the prefix of `kubevirt-ipam-controller-` is added, it won't be
`kubevirt-ipam-controller-controller-manager`

Note: we will need please a new tag on the new repo, so we can use the new image location.