### PR TITLE
Support primary network

### DIFF
--- a/pkg/claims/claims.go
+++ b/pkg/claims/claims.go
@@ -41,3 +41,7 @@ func OwnedByVMLabel(vmiName string) client.MatchingLabels {
 		virtv1.VirtualMachineLabel: vmiName,
 	}
 }
+
+func ComposeKey(vmName, networkName string) string {
+	return fmt.Sprintf("%s.%s", vmName, networkName)
+}

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -11,6 +11,8 @@ const (
 	NetworkRolePrimary NetworkRole = "primary"
 )
 
+const OVNPrimaryNetworkIPAMClaimAnnotation = "k8s.ovn.org/ovn-udn-ipamclaim-reference"
+
 type RelevantConfig struct {
 	Name               string      `json:"name"`
 	AllowPersistentIPs bool        `json:"allowPersistentIPs,omitempty"`

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -5,9 +5,16 @@ import (
 	"fmt"
 )
 
+type NetworkRole string
+
+const (
+	NetworkRolePrimary NetworkRole = "primary"
+)
+
 type RelevantConfig struct {
-	Name               string `json:"name"`
-	AllowPersistentIPs bool   `json:"allowPersistentIPs,omitempty"`
+	Name               string      `json:"name"`
+	AllowPersistentIPs bool        `json:"allowPersistentIPs,omitempty"`
+	Role               NetworkRole `json:"role,omitempty"`
 }
 
 func NewConfig(nadSpec string) (*RelevantConfig, error) {

--- a/pkg/ipamclaimswebhook/podmutator.go
+++ b/pkg/ipamclaimswebhook/podmutator.go
@@ -39,7 +39,9 @@ import (
 
 	virtv1 "kubevirt.io/api/core/v1"
 
+	"github.com/kubevirt/ipam-extensions/pkg/claims"
 	"github.com/kubevirt/ipam-extensions/pkg/config"
+	"github.com/kubevirt/ipam-extensions/pkg/udn"
 )
 
 // +kubebuilder:webhook:path=/mutate-v1-pod,mutating=true,failurePolicy=fail,groups="",resources=pods,verbs=create;update,versions=v1,name=ipam-claims.k8s.cni.cncf.io,admissionReviewVersions=v1,sideEffects=None
@@ -65,6 +67,8 @@ func (a *IPAMClaimsValet) Handle(ctx context.Context, request admission.Request)
 		return admission.Errored(http.StatusBadRequest, err)
 	}
 
+	log.Info("webhook handling event")
+
 	vmName, hasVMAnnotation := pod.Annotations["kubevirt.io/domain"]
 	if !hasVMAnnotation {
 		log.Info(
@@ -73,93 +77,43 @@ func (a *IPAMClaimsValet) Handle(ctx context.Context, request admission.Request)
 		return admission.Allowed("not a VM")
 	}
 
-	log.Info("webhook handling event")
 	networkSelectionElements, err := netutils.ParsePodNetworkAnnotation(pod)
 	if err != nil {
 		var goodTypeOfError *v1.NoK8sNetworkError
-		if errors.As(err, &goodTypeOfError) {
-			return admission.Allowed("no secondary networks requested")
+		if !errors.As(err, &goodTypeOfError) {
+			return admission.Errored(http.StatusBadRequest, fmt.Errorf("failed to parse pod network selection elements"))
 		}
-		return admission.Errored(http.StatusBadRequest, fmt.Errorf("failed to parse pod network selection elements"))
 	}
 
-	var (
-		hasChangedNetworkSelectionElements bool
-		podNetworkSelectionElements        = make([]v1.NetworkSelectionElement, 0, len(networkSelectionElements))
-	)
-	for _, networkSelectionElement := range networkSelectionElements {
-		nadName := types.NamespacedName{
-			Namespace: networkSelectionElement.Namespace,
-			Name:      networkSelectionElement.Name,
-		}.String()
-		log.Info(
-			"iterating network selection elements",
-			"NAD", nadName,
-		)
-		nadKey := types.NamespacedName{
-			Namespace: networkSelectionElement.Namespace,
-			Name:      networkSelectionElement.Name,
+	var newPod *corev1.Pod
+	hasChangedNetworkSelectionElements, err :=
+		ensureIPAMClaimRefAtNetworkSelectionElements(ctx, a.Client, pod, vmName, networkSelectionElements)
+	if err != nil {
+		return admission.Errored(http.StatusInternalServerError, err)
+	}
+	if hasChangedNetworkSelectionElements {
+		if newPod == nil {
+			newPod = pod.DeepCopy()
 		}
-
-		nad := v1.NetworkAttachmentDefinition{}
-		if err := a.Client.Get(context.Background(), nadKey, &nad); err != nil {
-			if k8serrors.IsNotFound(err) {
-				return admission.Allowed("NAD not found, will hang on scheduler")
-			}
+		if err := updatePodSelectionElements(newPod, networkSelectionElements); err != nil {
 			return admission.Errored(http.StatusInternalServerError, err)
 		}
-
-		pluginConfig, err := config.NewConfig(nad.Spec.Config)
-		if err != nil {
-			return admission.Errored(http.StatusInternalServerError, err)
-		}
-
-		if pluginConfig.AllowPersistentIPs {
-			log.Info(
-				"will request persistent IPs",
-				"NAD", nadName,
-				"network", pluginConfig.Name,
-			)
-
-			vmKey := types.NamespacedName{Namespace: pod.Namespace, Name: vmName}
-			vmi := &virtv1.VirtualMachineInstance{}
-			if err := a.Client.Get(context.Background(), vmKey, vmi); err != nil {
-				return admission.Errored(http.StatusInternalServerError, err)
-			}
-
-			vmiNets := vmiSecondaryNetworks(vmi)
-			networkName, foundNetworkName := vmiNets[nadKey.String()]
-			if !foundNetworkName {
-				log.Info(
-					"network name not found",
-					"NAD", nadName,
-					"network", networkName,
-				)
-				podNetworkSelectionElements = append(podNetworkSelectionElements, *networkSelectionElement)
-				continue
-			}
-
-			networkSelectionElement.IPAMClaimReference = fmt.Sprintf("%s.%s", vmName, networkName)
-			log.Info(
-				"requesting claim",
-				"NAD", nadName,
-				"network", pluginConfig.Name,
-				"claim", networkSelectionElement.IPAMClaimReference,
-			)
-			podNetworkSelectionElements = append(podNetworkSelectionElements, *networkSelectionElement)
-			hasChangedNetworkSelectionElements = true
-			continue
-		}
-		podNetworkSelectionElements = append(podNetworkSelectionElements, *networkSelectionElement)
 	}
 
-	if len(podNetworkSelectionElements) > 0 {
-		newPod, err := podWithUpdatedSelectionElements(pod, podNetworkSelectionElements)
-		if err != nil {
-			return admission.Errored(http.StatusInternalServerError, err)
+	newPrimaryNetworkIPAMClaimName, err := findNewPrimaryNetworkIPAMClaimName(ctx, a.Client, pod, vmName)
+	if err != nil {
+		return admission.Errored(http.StatusInternalServerError,
+			fmt.Errorf("failed looking for primary user defined IPAMClaim name: %v", err))
+	}
+	if newPrimaryNetworkIPAMClaimName != "" {
+		if newPod == nil {
+			newPod = pod.DeepCopy()
 		}
+		updatePodWithOVNPrimaryNetworkIPAMClaimAnnotation(newPod, newPrimaryNetworkIPAMClaimName)
+	}
 
-		if reflect.DeepEqual(newPod, pod) || !hasChangedNetworkSelectionElements {
+	if newPod != nil {
+		if reflect.DeepEqual(newPod, pod) {
 			return admission.Allowed("mutation not needed")
 		}
 
@@ -171,6 +125,7 @@ func (a *IPAMClaimsValet) Handle(ctx context.Context, request admission.Request)
 		log.Info("new pod annotations", "pod", newPod.Annotations)
 		return admission.PatchResponseFromRaw(request.Object.Raw, marshaledPod)
 	}
+
 	return admission.Allowed("carry on")
 }
 
@@ -195,12 +150,137 @@ func vmiSecondaryNetworks(vmi *virtv1.VirtualMachineInstance) map[string]string 
 	return indexedSecondaryNetworks
 }
 
-func podWithUpdatedSelectionElements(pod *corev1.Pod, networks []v1.NetworkSelectionElement) (*corev1.Pod, error) {
-	newPod := pod.DeepCopy()
+func updatePodSelectionElements(pod *corev1.Pod, networks []*v1.NetworkSelectionElement) error {
 	newNets, err := json.Marshal(networks)
 	if err != nil {
-		return nil, err
+		return err
 	}
-	newPod.Annotations[v1.NetworkAttachmentAnnot] = string(newNets)
-	return newPod, nil
+	pod.Annotations[v1.NetworkAttachmentAnnot] = string(newNets)
+	return nil
+}
+
+func updatePodWithOVNPrimaryNetworkIPAMClaimAnnotation(pod *corev1.Pod, primaryNetworkIPAMClaimName string) {
+	pod.Annotations[config.OVNPrimaryNetworkIPAMClaimAnnotation] = primaryNetworkIPAMClaimName
+}
+
+func ensureIPAMClaimRefAtNetworkSelectionElements(ctx context.Context,
+	cli client.Client, pod *corev1.Pod, vmName string,
+	networkSelectionElements []*v1.NetworkSelectionElement) (changed bool, err error) {
+	log := logf.FromContext(ctx)
+	hasChangedNetworkSelectionElements := false
+	for i, networkSelectionElement := range networkSelectionElements {
+		nadName := fmt.Sprintf("%s/%s", networkSelectionElement.Namespace, networkSelectionElement.Name)
+		log.Info(
+			"iterating network selection elements",
+			"NAD", nadName,
+		)
+		nadKey := types.NamespacedName{
+			Namespace: networkSelectionElement.Namespace,
+			Name:      networkSelectionElement.Name,
+		}
+
+		nad := v1.NetworkAttachmentDefinition{}
+		if err := cli.Get(context.Background(), nadKey, &nad); err != nil {
+			if k8serrors.IsNotFound(err) {
+				log.Info("NAD not found, will hang on scheduler", "NAD", nadName)
+				return false, nil
+			}
+			return false, err
+		}
+
+		pluginConfig, err := config.NewConfig(nad.Spec.Config)
+		if err != nil {
+			return false, err
+		}
+
+		if !pluginConfig.AllowPersistentIPs {
+			continue
+		}
+
+		log.Info(
+			"will request persistent IPs",
+			"NAD", nadName,
+			"network", pluginConfig.Name,
+		)
+
+		vmKey := types.NamespacedName{Namespace: pod.Namespace, Name: vmName}
+		vmi := &virtv1.VirtualMachineInstance{}
+		if err := cli.Get(context.Background(), vmKey, vmi); err != nil {
+			return false, err
+		}
+
+		vmiNets := vmiSecondaryNetworks(vmi)
+		networkName, foundNetworkName := vmiNets[nadKey.String()]
+		if !foundNetworkName {
+			log.Info(
+				"network name not found",
+				"NAD", nadName,
+				"network", networkName,
+			)
+			continue
+		}
+
+		networkSelectionElements[i].IPAMClaimReference = claims.ComposeKey(vmName, networkName)
+		log.Info(
+			"requesting claim",
+			"NAD", nadName,
+			"network", pluginConfig.Name,
+			"claim", networkSelectionElement.IPAMClaimReference,
+		)
+		hasChangedNetworkSelectionElements = true
+		continue
+	}
+	return hasChangedNetworkSelectionElements, nil
+}
+
+func findNewPrimaryNetworkIPAMClaimName(ctx context.Context,
+	cli client.Client, pod *corev1.Pod, vmName string) (string, error) {
+	log := logf.FromContext(ctx)
+	if pod.Annotations[config.OVNPrimaryNetworkIPAMClaimAnnotation] != "" {
+		return "", nil
+	}
+	primaryNetworkNAD, err := udn.FindPrimaryNetwork(ctx, cli, pod.Namespace)
+	if err != nil {
+		return "", err
+	}
+	if primaryNetworkNAD == nil {
+		return "", nil
+	}
+	pluginConfig, err := config.NewConfig(primaryNetworkNAD.Spec.Config)
+	if err != nil {
+		return "", err
+	}
+
+	if !pluginConfig.AllowPersistentIPs {
+		return "", nil
+	}
+
+	log.Info(
+		"will request primary network persistent IPs",
+		"NAD", client.ObjectKeyFromObject(primaryNetworkNAD),
+		"network", pluginConfig.Name,
+	)
+	vmKey := types.NamespacedName{Namespace: pod.Namespace, Name: vmName}
+	vmi := &virtv1.VirtualMachineInstance{}
+	if err := cli.Get(context.Background(), vmKey, vmi); err != nil {
+		return "", err
+	}
+
+	networkName := vmiPodNetworkName(vmi)
+	if networkName == "" {
+		log.Info("vmi has no pod network primary UDN ipam claim will not be created", "vmi", vmKey.String())
+		return "", nil
+	}
+
+	return claims.ComposeKey(vmi.Name, networkName), nil
+}
+
+// returns the name of the kubevirt VM pod network
+func vmiPodNetworkName(vmi *virtv1.VirtualMachineInstance) string {
+	for _, network := range vmi.Spec.Networks {
+		if network.Pod != nil {
+			return network.Name
+		}
+	}
+	return ""
 }

--- a/pkg/ipamclaimswebhook/podmutator_test.go
+++ b/pkg/ipamclaimswebhook/podmutator_test.go
@@ -36,7 +36,7 @@ import (
 type testConfig struct {
 	inputVM                   *virtv1.VirtualMachine
 	inputVMI                  *virtv1.VirtualMachineInstance
-	inputNAD                  *nadv1.NetworkAttachmentDefinition
+	inputNADs                 []*nadv1.NetworkAttachmentDefinition
 	inputPod                  *corev1.Pod
 	expectedAdmissionResponse admission.Response
 }
@@ -86,8 +86,8 @@ var _ = Describe("KubeVirt IPAM launcher pod mutato machine", Serial, func() {
 			initialObjects = append(initialObjects, config.inputVMI)
 		}
 
-		if config.inputNAD != nil {
-			initialObjects = append(initialObjects, config.inputNAD)
+		for _, nad := range config.inputNADs {
+			initialObjects = append(initialObjects, nad)
 		}
 
 		ctrlOptions := controllerruntime.Options{
@@ -111,25 +111,81 @@ var _ = Describe("KubeVirt IPAM launcher pod mutato machine", Serial, func() {
 			Equal(config.expectedAdmissionResponse),
 		)
 	},
-		Entry("pod not requesting secondary attachments is accepted", testConfig{
+		Entry("pod not beloging to a VM and not requesting secondary "+
+			"attachments and no primary user defined network is accepted", testConfig{
 			inputVM:  dummyVM(nadName),
 			inputVMI: dummyVMI(nadName),
-			inputNAD: dummyNAD(nadName),
+			inputNADs: []*nadv1.NetworkAttachmentDefinition{
+				dummyNAD(nadName),
+			},
 			inputPod: &corev1.Pod{},
 			expectedAdmissionResponse: admission.Response{
 				AdmissionResponse: admissionv1.AdmissionResponse{
 					Allowed: true,
 					Result: &metav1.Status{
-						Message: "no secondary networks requested",
+						Message: "not a VM",
 						Code:    http.StatusOK,
 					},
 				},
 			},
 		}),
-		Entry("vm launcher pod with an attachment to a network with persistent IPs enabled requests an IPAMClaim", testConfig{
+		Entry("vm launcher pod with an attachment to a primary and secondary user "+
+			"defined network with persistent IPs enabled requests an IPAMClaim", testConfig{
 			inputVM:  dummyVM(nadName),
 			inputVMI: dummyVMI(nadName),
-			inputNAD: dummyNAD(nadName),
+			inputNADs: []*nadv1.NetworkAttachmentDefinition{
+				dummyNAD(nadName),
+				dummyPrimaryNetworkNAD(nadName),
+			},
+			inputPod: dummyPodForVM(nadName, vmName),
+			expectedAdmissionResponse: admission.Response{
+				AdmissionResponse: admissionv1.AdmissionResponse{
+					Allowed:   true,
+					PatchType: &patchType,
+				},
+				Patches: []jsonpatch.JsonPatchOperation{
+					{
+						Operation: "add",
+						Path:      "/metadata/annotations/k8s.ovn.org~1ovn-udn-ipamclaim-reference",
+						Value:     "vm1.podnet",
+					},
+					{
+						Operation: "replace",
+						Path:      "/metadata/annotations/k8s.v1.cni.cncf.io~1networks",
+						Value:     "[{\"name\":\"supadupanet\",\"namespace\":\"ns1\",\"ipam-claim-reference\":\"vm1.randomnet\"}]",
+					},
+				},
+			},
+		}),
+		Entry("vm launcher pod with with primary user defined network defined "+
+			"at namespace with persistent IPs enabled requests an IPAMClaim", testConfig{
+			inputVM:  dummyVM(nadName),
+			inputVMI: dummyVMI(nadName),
+			inputNADs: []*nadv1.NetworkAttachmentDefinition{
+				dummyPrimaryNetworkNAD(nadName),
+			},
+			inputPod: dummyPodForVM("" /*without network selection element*/, vmName),
+			expectedAdmissionResponse: admission.Response{
+				AdmissionResponse: admissionv1.AdmissionResponse{
+					Allowed:   true,
+					PatchType: &patchType,
+				},
+				Patches: []jsonpatch.JsonPatchOperation{
+					{
+						Operation: "add",
+						Path:      "/metadata/annotations/k8s.ovn.org~1ovn-udn-ipamclaim-reference",
+						Value:     "vm1.podnet",
+					},
+				},
+			},
+		}),
+		Entry("vm launcher pod with an attachment to a secondary user defined "+
+			"network with persistent IPs enabled requests an IPAMClaim", testConfig{
+			inputVM:  dummyVM(nadName),
+			inputVMI: dummyVMI(nadName),
+			inputNADs: []*nadv1.NetworkAttachmentDefinition{
+				dummyNAD(nadName),
+			},
 			inputPod: dummyPodForVM(nadName, vmName),
 			expectedAdmissionResponse: admission.Response{
 				AdmissionResponse: admissionv1.AdmissionResponse{
@@ -148,20 +204,24 @@ var _ = Describe("KubeVirt IPAM launcher pod mutato machine", Serial, func() {
 		Entry("vm launcher pod with an attachment to a network *without* persistentIPs is accepted", testConfig{
 			inputVM:  dummyVM(nadName),
 			inputVMI: dummyVMI(nadName),
-			inputNAD: dummyNADWithoutPersistentIPs(nadName),
+			inputNADs: []*nadv1.NetworkAttachmentDefinition{
+				dummyNADWithoutPersistentIPs(nadName),
+			},
 			inputPod: dummyPodForVM(nadName, vmName),
 			expectedAdmissionResponse: admission.Response{
 				AdmissionResponse: admissionv1.AdmissionResponse{
 					Allowed: true,
 					Result: &metav1.Status{
-						Message: "mutation not needed",
+						Message: "carry on",
 						Code:    http.StatusOK,
 					},
 				},
 			},
 		}),
 		Entry("pod not belonging to a VM with an attachment to a network with persistent IPs enabled is accepted", testConfig{
-			inputNAD: dummyNAD(nadName),
+			inputNADs: []*nadv1.NetworkAttachmentDefinition{
+				dummyNAD(nadName),
+			},
 			inputPod: dummyPod(nadName),
 			expectedAdmissionResponse: admission.Response{
 				AdmissionResponse: admissionv1.AdmissionResponse{
@@ -176,8 +236,10 @@ var _ = Describe("KubeVirt IPAM launcher pod mutato machine", Serial, func() {
 		Entry("pod requesting an attachment via a NAD with an invalid configuration throws a BAD REQUEST", testConfig{
 			inputVM:  dummyVM(nadName),
 			inputVMI: dummyVMI(nadName),
-			inputNAD: dummyNAD(nadName),
-			inputPod: pod("{not json}", nil),
+			inputNADs: []*nadv1.NetworkAttachmentDefinition{
+				dummyNAD(nadName),
+			},
+			inputPod: dummyPodForVM("{not json}", vmName),
 			expectedAdmissionResponse: admission.Response{
 				AdmissionResponse: admissionv1.AdmissionResponse{
 					Allowed: false,
@@ -196,14 +258,16 @@ var _ = Describe("KubeVirt IPAM launcher pod mutato machine", Serial, func() {
 				AdmissionResponse: admissionv1.AdmissionResponse{
 					Allowed: true,
 					Result: &metav1.Status{
-						Message: "NAD not found, will hang on scheduler",
+						Message: "carry on",
 						Code:    http.StatusOK,
 					},
 				},
 			},
 		}),
 		Entry("launcher pod whose VMI is not found throws a server error", testConfig{
-			inputNAD: dummyNAD(nadName),
+			inputNADs: []*nadv1.NetworkAttachmentDefinition{
+				dummyNAD(nadName),
+			},
 			inputPod: dummyPodForVM(nadName, vmName),
 			expectedAdmissionResponse: admission.Response{
 				AdmissionResponse: admissionv1.AdmissionResponse{
@@ -261,7 +325,7 @@ func dummyVMISpec(nadName string) virtv1.VirtualMachineInstanceSpec {
 	}
 }
 
-func dummyNAD(nadName string) *nadv1.NetworkAttachmentDefinition {
+func dummyNADWithConfig(nadName string, config string) *nadv1.NetworkAttachmentDefinition {
 	namespaceAndName := strings.Split(nadName, "/")
 	return &nadv1.NetworkAttachmentDefinition{
 		ObjectMeta: metav1.ObjectMeta{
@@ -269,22 +333,20 @@ func dummyNAD(nadName string) *nadv1.NetworkAttachmentDefinition {
 			Name:      namespaceAndName[1],
 		},
 		Spec: nadv1.NetworkAttachmentDefinitionSpec{
-			Config: `{"name": "goodnet", "allowPersistentIPs": true}`,
+			Config: config,
 		},
 	}
 }
 
+func dummyNAD(nadName string) *nadv1.NetworkAttachmentDefinition {
+	return dummyNADWithConfig(nadName, `{"name": "goodnet", "allowPersistentIPs": true}`)
+}
+
+func dummyPrimaryNetworkNAD(nadName string) *nadv1.NetworkAttachmentDefinition {
+	return dummyNADWithConfig(nadName+"primary", `{"name": "primarynet", "role": "primary", "allowPersistentIPs": true}`)
+}
 func dummyNADWithoutPersistentIPs(nadName string) *nadv1.NetworkAttachmentDefinition {
-	namespaceAndName := strings.Split(nadName, "/")
-	return &nadv1.NetworkAttachmentDefinition{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: namespaceAndName[0],
-			Name:      namespaceAndName[1],
-		},
-		Spec: nadv1.NetworkAttachmentDefinitionSpec{
-			Config: `{"name": "goodnet"}`,
-		},
-	}
+	return dummyNADWithConfig(nadName, `{"name": "goodnet"}`)
 }
 
 func podAdmissionRequest(pod *corev1.Pod) admission.Request {
@@ -312,8 +374,9 @@ func dummyPod(nadName string) *corev1.Pod {
 }
 
 func pod(nadName string, annotations map[string]string) *corev1.Pod {
-	baseAnnotations := map[string]string{
-		nadv1.NetworkAttachmentAnnot: nadName,
+	baseAnnotations := map[string]string{}
+	if nadName != "" {
+		baseAnnotations[nadv1.NetworkAttachmentAnnot] = nadName
 	}
 	for k, v := range annotations {
 		baseAnnotations[k] = v

--- a/pkg/udn/primary_network.go
+++ b/pkg/udn/primary_network.go
@@ -1,0 +1,33 @@
+package udn
+
+import (
+	"context"
+	"fmt"
+
+	v1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/kubevirt/ipam-extensions/pkg/config"
+)
+
+func FindPrimaryNetwork(ctx context.Context,
+	cli client.Client,
+	namespace string) (*v1.NetworkAttachmentDefinition, error) {
+	nadList := v1.NetworkAttachmentDefinitionList{}
+	if err := cli.List(ctx, &nadList, client.InNamespace(namespace)); err != nil {
+		return nil, fmt.Errorf("failed listing nads for pod namespace %q", namespace)
+	}
+
+	for _, nad := range nadList.Items {
+		netConfig, err := config.NewConfig(nad.Spec.Config)
+		if err != nil {
+			return nil, fmt.Errorf("failed to extract the relevant NAD information")
+		}
+		if netConfig.Role == config.NetworkRolePrimary {
+			return ptr.To(nad), nil
+		}
+	}
+	return nil, nil
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR add support for ovn-kubernetes primary networks by doing a pair of things:
- Creating an IPAMClaim if there is a primary network at namespace
- Annotating the virt-launcher pod with  `k8s.ovn.org/ovn-udn-ipamclaim-reference`

TODO:
- [x] controller unit test 
- [x] webhook unit test 
- [ ] e2e test

**Release note**:
```release-note
Support ovn-kubernetes primary network feature.
```
