### PR TITLE
Rename VMI reconciler

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -45,7 +45,7 @@ import (
 	nadv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 
 	"github.com/kubevirt/ipam-extensions/pkg/ipamclaimswebhook"
-	"github.com/kubevirt/ipam-extensions/pkg/vmnetworkscontroller"
+	"github.com/kubevirt/ipam-extensions/pkg/vminetworkscontroller"
 	//+kubebuilder:scaffold:imports
 )
 
@@ -156,8 +156,8 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err = vmnetworkscontroller.NewVMReconciler(mgr).Setup(); err != nil {
-		setupLog.Error(err, "unable to create controller", "controller", "VirtualMachine")
+	if err = vminetworkscontroller.NewVMIReconciler(mgr).Setup(); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "VirtualMachineInstance")
 		os.Exit(1)
 	}
 

--- a/pkg/vminetworkscontroller/vmi_controller_test.go
+++ b/pkg/vminetworkscontroller/vmi_controller_test.go
@@ -1,4 +1,4 @@
-package vmnetworkscontroller
+package vminetworkscontroller
 
 import (
 	"context"
@@ -48,7 +48,7 @@ type testConfig struct {
 	expectedIPAMClaims []ipamclaimsapi.IPAMClaim
 }
 
-var _ = Describe("vm IPAM controller", Serial, func() {
+var _ = Describe("vmi IPAM controller", Serial, func() {
 	BeforeEach(func() {
 		log.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 		testEnv = &envtest.Environment{}
@@ -117,7 +117,7 @@ var _ = Describe("vm IPAM controller", Serial, func() {
 		mgr, err := controllerruntime.NewManager(&rest.Config{}, ctrlOptions)
 		Expect(err).NotTo(HaveOccurred())
 
-		reconcileMachine := NewVMReconciler(mgr)
+		reconcileMachine := NewVMIReconciler(mgr)
 		if config.expectedError != nil {
 			_, err := reconcileMachine.Reconcile(context.Background(), controllerruntime.Request{NamespacedName: vmiKey})
 			Expect(err).To(MatchError(config.expectedError))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
It reconciles VMI not VM, hence rename accordingly.
Rename folder, files and package accordingly.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
