### PR TITLE
Fix Finalizer logic

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -46,6 +46,7 @@ import (
 
 	"github.com/kubevirt/ipam-extensions/pkg/ipamclaimswebhook"
 	"github.com/kubevirt/ipam-extensions/pkg/vminetworkscontroller"
+	"github.com/kubevirt/ipam-extensions/pkg/vmnetworkscontroller"
 	//+kubebuilder:scaffold:imports
 )
 
@@ -153,6 +154,11 @@ func main() {
 	}
 	if err := mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
 		setupLog.Error(err, "unable to set up ready check")
+		os.Exit(1)
+	}
+
+	if err = vmnetworkscontroller.NewVMReconciler(mgr).Setup(); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "VirtualMachine")
 		os.Exit(1)
 	}
 

--- a/pkg/claims/claims.go
+++ b/pkg/claims/claims.go
@@ -1,0 +1,43 @@
+package claims
+
+import (
+	"context"
+	"fmt"
+
+	apitypes "k8s.io/apimachinery/pkg/types"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	ipamclaimsapi "github.com/k8snetworkplumbingwg/ipamclaims/pkg/crd/ipamclaims/v1alpha1"
+
+	virtv1 "kubevirt.io/api/core/v1"
+)
+
+const KubevirtVMFinalizer = "kubevirt.io/persistent-ipam"
+
+func Cleanup(c client.Client, vmiKey apitypes.NamespacedName) error {
+	ipamClaims := &ipamclaimsapi.IPAMClaimList{}
+	listOpts := []client.ListOption{
+		client.InNamespace(vmiKey.Namespace),
+		OwnedByVMLabel(vmiKey.Name),
+	}
+	if err := c.List(context.Background(), ipamClaims, listOpts...); err != nil {
+		return fmt.Errorf("could not get list of IPAMClaims owned by VM %q: %w", vmiKey.String(), err)
+	}
+
+	for _, claim := range ipamClaims.Items {
+		if controllerutil.RemoveFinalizer(&claim, KubevirtVMFinalizer) {
+			if err := c.Update(context.Background(), &claim, &client.UpdateOptions{}); err != nil {
+				return client.IgnoreNotFound(err)
+			}
+		}
+	}
+	return nil
+}
+
+func OwnedByVMLabel(vmiName string) client.MatchingLabels {
+	return map[string]string{
+		virtv1.VirtualMachineLabel: vmiName,
+	}
+}

--- a/pkg/vminetworkscontroller/vmi_controller.go
+++ b/pkg/vminetworkscontroller/vmi_controller.go
@@ -17,7 +17,6 @@ import (
 
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
@@ -26,10 +25,9 @@ import (
 
 	virtv1 "kubevirt.io/api/core/v1"
 
+	"github.com/kubevirt/ipam-extensions/pkg/claims"
 	"github.com/kubevirt/ipam-extensions/pkg/config"
 )
-
-const kubevirtVMFinalizer = "kubevirt.io/persistent-ipam"
 
 // VirtualMachineInstanceReconciler reconciles a VirtualMachineInstance object
 type VirtualMachineInstanceReconciler struct {
@@ -69,7 +67,7 @@ func (r *VirtualMachineInstanceReconciler) Reconcile(
 	}
 
 	if shouldCleanFinalizers(vmi, vm) {
-		if err := r.Cleanup(request.NamespacedName); err != nil {
+		if err := claims.Cleanup(r.Client, request.NamespacedName); err != nil {
 			return controllerruntime.Result{}, fmt.Errorf("failed removing the IPAMClaims finalizer: %w", err)
 		}
 		return controllerruntime.Result{}, nil
@@ -92,8 +90,8 @@ func (r *VirtualMachineInstanceReconciler) Reconcile(
 				Name:            claimKey,
 				Namespace:       vmi.Namespace,
 				OwnerReferences: []metav1.OwnerReference{ownerInfo},
-				Finalizers:      []string{kubevirtVMFinalizer},
-				Labels:          ownedByVMLabel(vmi.Name),
+				Finalizers:      []string{claims.KubevirtVMFinalizer},
+				Labels:          claims.OwnedByVMLabel(vmi.Name),
 			},
 			Spec: ipamclaimsapi.IPAMClaimSpec{
 				Network: netConfigName,
@@ -198,33 +196,6 @@ func (r *VirtualMachineInstanceReconciler) vmiNetworksClaimingIPAM(
 		}
 	}
 	return vmiNets, nil
-}
-
-func (r *VirtualMachineInstanceReconciler) Cleanup(vmiKey apitypes.NamespacedName) error {
-	ipamClaims := &ipamclaimsapi.IPAMClaimList{}
-	listOpts := []client.ListOption{
-		client.InNamespace(vmiKey.Namespace),
-		ownedByVMLabel(vmiKey.Name),
-	}
-	if err := r.Client.List(context.Background(), ipamClaims, listOpts...); err != nil {
-		return fmt.Errorf("could not get list of IPAMClaims owned by VM %q: %w", vmiKey.String(), err)
-	}
-
-	for _, claim := range ipamClaims.Items {
-		removedFinalizer := controllerutil.RemoveFinalizer(&claim, kubevirtVMFinalizer)
-		if removedFinalizer {
-			if err := r.Client.Update(context.Background(), &claim, &client.UpdateOptions{}); err != nil {
-				return client.IgnoreNotFound(err)
-			}
-		}
-	}
-	return nil
-}
-
-func ownedByVMLabel(vmiName string) client.MatchingLabels {
-	return map[string]string{
-		virtv1.VirtualMachineLabel: vmiName,
-	}
 }
 
 func shouldCleanFinalizers(vmi *virtv1.VirtualMachineInstance, vm *virtv1.VirtualMachine) bool {

--- a/pkg/vminetworkscontroller/vmi_controller_test.go
+++ b/pkg/vminetworkscontroller/vmi_controller_test.go
@@ -29,6 +29,8 @@ import (
 
 	ipamclaimsapi "github.com/k8snetworkplumbingwg/ipamclaims/pkg/crd/ipamclaims/v1alpha1"
 	nadv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+
+	"github.com/kubevirt/ipam-extensions/pkg/claims"
 )
 
 func TestController(t *testing.T) {
@@ -134,7 +136,7 @@ var _ = Describe("VMI IPAM controller", Serial, func() {
 		if len(config.expectedIPAMClaims) > 0 {
 			ipamClaimList := &ipamclaimsapi.IPAMClaimList{}
 
-			Expect(mgr.GetClient().List(context.Background(), ipamClaimList, ownedByVMLabel(vmName))).To(Succeed())
+			Expect(mgr.GetClient().List(context.Background(), ipamClaimList, claims.OwnedByVMLabel(vmName))).To(Succeed())
 			Expect(ipamClaimsCleaner(ipamClaimList.Items...)).To(ConsistOf(config.expectedIPAMClaims))
 		}
 	},
@@ -148,8 +150,8 @@ var _ = Describe("VMI IPAM controller", Serial, func() {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:       fmt.Sprintf("%s.%s", vmName, "randomnet"),
 						Namespace:  namespace,
-						Finalizers: []string{kubevirtVMFinalizer},
-						Labels:     ownedByVMLabel(vmName),
+						Finalizers: []string{claims.KubevirtVMFinalizer},
+						Labels:     claims.OwnedByVMLabel(vmName),
 						OwnerReferences: []metav1.OwnerReference{{
 							APIVersion:         "kubevirt.io/v1",
 							Kind:               "VirtualMachine",
@@ -201,8 +203,8 @@ var _ = Describe("VMI IPAM controller", Serial, func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       fmt.Sprintf("%s.%s", vmName, "randomnet"),
 					Namespace:  namespace,
-					Finalizers: []string{kubevirtVMFinalizer},
-					Labels:     ownedByVMLabel(vmName),
+					Finalizers: []string{claims.KubevirtVMFinalizer},
+					Labels:     claims.OwnedByVMLabel(vmName),
 				},
 				Spec: ipamclaimsapi.IPAMClaimSpec{Network: "doesitmatter?"},
 			},
@@ -211,7 +213,7 @@ var _ = Describe("VMI IPAM controller", Serial, func() {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "vm1.randomnet",
 						Namespace: "ns1",
-						Labels:    ownedByVMLabel(vmName),
+						Labels:    claims.OwnedByVMLabel(vmName),
 					},
 					Spec: ipamclaimsapi.IPAMClaimSpec{Network: "doesitmatter?"},
 				},
@@ -224,8 +226,8 @@ var _ = Describe("VMI IPAM controller", Serial, func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       fmt.Sprintf("%s.%s", vmName, "randomnet"),
 					Namespace:  namespace,
-					Finalizers: []string{kubevirtVMFinalizer},
-					Labels:     ownedByVMLabel(vmName),
+					Finalizers: []string{claims.KubevirtVMFinalizer},
+					Labels:     claims.OwnedByVMLabel(vmName),
 				},
 				Spec: ipamclaimsapi.IPAMClaimSpec{Network: "doesitmatter?"},
 			},
@@ -234,8 +236,8 @@ var _ = Describe("VMI IPAM controller", Serial, func() {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:       "vm1.randomnet",
 						Namespace:  "ns1",
-						Finalizers: []string{kubevirtVMFinalizer},
-						Labels:     ownedByVMLabel(vmName),
+						Finalizers: []string{claims.KubevirtVMFinalizer},
+						Labels:     claims.OwnedByVMLabel(vmName),
 					},
 					Spec: ipamclaimsapi.IPAMClaimSpec{Network: "doesitmatter?"},
 				},
@@ -248,8 +250,8 @@ var _ = Describe("VMI IPAM controller", Serial, func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       fmt.Sprintf("%s.%s", vmName, "randomnet"),
 					Namespace:  namespace,
-					Finalizers: []string{kubevirtVMFinalizer},
-					Labels:     ownedByVMLabel(vmName),
+					Finalizers: []string{claims.KubevirtVMFinalizer},
+					Labels:     claims.OwnedByVMLabel(vmName),
 				},
 				Spec: ipamclaimsapi.IPAMClaimSpec{Network: "doesitmatter?"},
 			},
@@ -258,7 +260,7 @@ var _ = Describe("VMI IPAM controller", Serial, func() {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "vm1.randomnet",
 						Namespace: "ns1",
-						Labels:    ownedByVMLabel(vmName),
+						Labels:    claims.OwnedByVMLabel(vmName),
 					},
 					Spec: ipamclaimsapi.IPAMClaimSpec{Network: "doesitmatter?"},
 				},
@@ -272,8 +274,8 @@ var _ = Describe("VMI IPAM controller", Serial, func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       fmt.Sprintf("%s.%s", vmName, "randomnet"),
 					Namespace:  namespace,
-					Finalizers: []string{kubevirtVMFinalizer},
-					Labels:     ownedByVMLabel(vmName),
+					Finalizers: []string{claims.KubevirtVMFinalizer},
+					Labels:     claims.OwnedByVMLabel(vmName),
 					OwnerReferences: []metav1.OwnerReference{{
 						Name:               vmName,
 						UID:                dummyUID,
@@ -289,8 +291,8 @@ var _ = Describe("VMI IPAM controller", Serial, func() {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:       "vm1.randomnet",
 						Namespace:  "ns1",
-						Finalizers: []string{kubevirtVMFinalizer},
-						Labels:     ownedByVMLabel(vmName),
+						Finalizers: []string{claims.KubevirtVMFinalizer},
+						Labels:     claims.OwnedByVMLabel(vmName),
 						OwnerReferences: []metav1.OwnerReference{{
 							Name:               vmName,
 							UID:                dummyUID,
@@ -310,8 +312,8 @@ var _ = Describe("VMI IPAM controller", Serial, func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       fmt.Sprintf("%s.%s", vmName, "randomnet"),
 					Namespace:  namespace,
-					Finalizers: []string{kubevirtVMFinalizer},
-					Labels:     ownedByVMLabel(vmName),
+					Finalizers: []string{claims.KubevirtVMFinalizer},
+					Labels:     claims.OwnedByVMLabel(vmName),
 				},
 				Spec: ipamclaimsapi.IPAMClaimSpec{Network: "doesitmatter?"},
 			},
@@ -320,7 +322,7 @@ var _ = Describe("VMI IPAM controller", Serial, func() {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "vm1.randomnet",
 						Namespace: "ns1",
-						Labels:    ownedByVMLabel(vmName),
+						Labels:    claims.OwnedByVMLabel(vmName),
 					},
 					Spec: ipamclaimsapi.IPAMClaimSpec{Network: "doesitmatter?"},
 				},
@@ -355,8 +357,8 @@ var _ = Describe("VMI IPAM controller", Serial, func() {
 							UID:        dummyUID,
 						},
 					},
-					Labels:     ownedByVMLabel(vmName),
-					Finalizers: []string{kubevirtVMFinalizer},
+					Labels:     claims.OwnedByVMLabel(vmName),
+					Finalizers: []string{claims.KubevirtVMFinalizer},
 				},
 				Spec: ipamclaimsapi.IPAMClaimSpec{Network: "doesitmatter?"},
 			},
@@ -366,7 +368,7 @@ var _ = Describe("VMI IPAM controller", Serial, func() {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "vm1.randomnet",
 						Namespace: "ns1",
-						Labels:    ownedByVMLabel(vmName),
+						Labels:    claims.OwnedByVMLabel(vmName),
 						OwnerReferences: []metav1.OwnerReference{
 							{
 								APIVersion: "v1",
@@ -375,7 +377,7 @@ var _ = Describe("VMI IPAM controller", Serial, func() {
 								UID:        dummyUID,
 							},
 						},
-						Finalizers: []string{kubevirtVMFinalizer},
+						Finalizers: []string{claims.KubevirtVMFinalizer},
 					},
 					Spec: ipamclaimsapi.IPAMClaimSpec{Network: "doesitmatter?"},
 				},
@@ -397,8 +399,8 @@ var _ = Describe("VMI IPAM controller", Serial, func() {
 							UID:        unexpectedUID,
 						},
 					},
-					Labels:     ownedByVMLabel(vmName),
-					Finalizers: []string{kubevirtVMFinalizer},
+					Labels:     claims.OwnedByVMLabel(vmName),
+					Finalizers: []string{claims.KubevirtVMFinalizer},
 				},
 				Spec: ipamclaimsapi.IPAMClaimSpec{Network: "doesitmatter?"},
 			},
@@ -413,8 +415,8 @@ var _ = Describe("VMI IPAM controller", Serial, func() {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:       "vm1.randomnet",
 						Namespace:  "ns1",
-						Labels:     ownedByVMLabel(vmName),
-						Finalizers: []string{kubevirtVMFinalizer},
+						Labels:     claims.OwnedByVMLabel(vmName),
+						Finalizers: []string{claims.KubevirtVMFinalizer},
 						OwnerReferences: []metav1.OwnerReference{{
 							APIVersion:         "kubevirt.io/v1",
 							Kind:               "VirtualMachineInstance",

--- a/pkg/vminetworkscontroller/vmi_controller_test.go
+++ b/pkg/vminetworkscontroller/vmi_controller_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -14,6 +15,7 @@ import (
 	apitypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
+	"k8s.io/utils/ptr"
 
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -31,7 +33,7 @@ import (
 
 func TestController(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Controller test suite")
+	RunSpecs(t, "VMI Controller test suite")
 }
 
 var (
@@ -48,7 +50,9 @@ type testConfig struct {
 	expectedIPAMClaims []ipamclaimsapi.IPAMClaim
 }
 
-var _ = Describe("vmi IPAM controller", Serial, func() {
+const dummyUID = "dummyUID"
+
+var _ = Describe("VMI IPAM controller", Serial, func() {
 	BeforeEach(func() {
 		log.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 		testEnv = &envtest.Environment{}
@@ -69,7 +73,6 @@ var _ = Describe("vmi IPAM controller", Serial, func() {
 		nadName       = "ns1/superdupernad"
 		namespace     = "ns1"
 		vmName        = "vm1"
-		dummyUID      = "dummyUID"
 		unexpectedUID = "unexpectedUID"
 	)
 
@@ -118,13 +121,13 @@ var _ = Describe("vmi IPAM controller", Serial, func() {
 		mgr, err := controllerruntime.NewManager(&rest.Config{}, ctrlOptions)
 		Expect(err).NotTo(HaveOccurred())
 
-		reconcileMachine := NewVMIReconciler(mgr)
+		vmiReconciler := NewVMIReconciler(mgr)
 		if config.expectedError != nil {
-			_, err := reconcileMachine.Reconcile(context.Background(), controllerruntime.Request{NamespacedName: vmiKey})
+			_, err := vmiReconciler.Reconcile(context.Background(), controllerruntime.Request{NamespacedName: vmiKey})
 			Expect(err).To(MatchError(config.expectedError))
 		} else {
 			Expect(
-				reconcileMachine.Reconcile(context.Background(), controllerruntime.Request{NamespacedName: vmiKey}),
+				vmiReconciler.Reconcile(context.Background(), controllerruntime.Request{NamespacedName: vmiKey}),
 			).To(Equal(config.expectedResponse))
 		}
 
@@ -143,11 +146,17 @@ var _ = Describe("vmi IPAM controller", Serial, func() {
 			expectedIPAMClaims: []ipamclaimsapi.IPAMClaim{
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:            fmt.Sprintf("%s.%s", vmName, "randomnet"),
-						Namespace:       namespace,
-						Finalizers:      []string{kubevirtVMFinalizer},
-						Labels:          ownedByVMLabel(vmName),
-						OwnerReferences: []metav1.OwnerReference{{Name: vmName}},
+						Name:       fmt.Sprintf("%s.%s", vmName, "randomnet"),
+						Namespace:  namespace,
+						Finalizers: []string{kubevirtVMFinalizer},
+						Labels:     ownedByVMLabel(vmName),
+						OwnerReferences: []metav1.OwnerReference{{
+							APIVersion:         "kubevirt.io/v1",
+							Kind:               "VirtualMachine",
+							Name:               vmName,
+							Controller:         ptr.To(true),
+							BlockOwnerDeletion: ptr.To(true)},
+						},
 					},
 					Spec: ipamclaimsapi.IPAMClaimSpec{Network: "goodnet"},
 				},
@@ -186,7 +195,116 @@ var _ = Describe("vmi IPAM controller", Serial, func() {
 		Entry("the VMI does not exist on the datastore - it might have been deleted in the meantime", testConfig{
 			expectedResponse: reconcile.Result{},
 		}),
-		Entry("the VMI was deleted, thus the existing IPAMClaims finalizers must be removed", testConfig{
+		Entry("the VMI was deleted (VM doesnt exists as well), thus IPAMClaims finalizers must be removed", testConfig{
+			expectedResponse: reconcile.Result{},
+			existingIPAMClaim: &ipamclaimsapi.IPAMClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       fmt.Sprintf("%s.%s", vmName, "randomnet"),
+					Namespace:  namespace,
+					Finalizers: []string{kubevirtVMFinalizer},
+					Labels:     ownedByVMLabel(vmName),
+				},
+				Spec: ipamclaimsapi.IPAMClaimSpec{Network: "doesitmatter?"},
+			},
+			expectedIPAMClaims: []ipamclaimsapi.IPAMClaim{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "vm1.randomnet",
+						Namespace: "ns1",
+						Labels:    ownedByVMLabel(vmName),
+					},
+					Spec: ipamclaimsapi.IPAMClaimSpec{Network: "doesitmatter?"},
+				},
+			},
+		}),
+		Entry("the VM was stopped, thus the existing IPAMClaims finalizers should be kept", testConfig{
+			inputVM:          dummyVM(dummyVMISpec(nadName)),
+			expectedResponse: reconcile.Result{},
+			existingIPAMClaim: &ipamclaimsapi.IPAMClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       fmt.Sprintf("%s.%s", vmName, "randomnet"),
+					Namespace:  namespace,
+					Finalizers: []string{kubevirtVMFinalizer},
+					Labels:     ownedByVMLabel(vmName),
+				},
+				Spec: ipamclaimsapi.IPAMClaimSpec{Network: "doesitmatter?"},
+			},
+			expectedIPAMClaims: []ipamclaimsapi.IPAMClaim{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       "vm1.randomnet",
+						Namespace:  "ns1",
+						Finalizers: []string{kubevirtVMFinalizer},
+						Labels:     ownedByVMLabel(vmName),
+					},
+					Spec: ipamclaimsapi.IPAMClaimSpec{Network: "doesitmatter?"},
+				},
+			},
+		}),
+		Entry("standalone VMI, marked for deletion, without pods, thus IPAMClaims finalizers must be removed", testConfig{
+			inputVMI:         dummyMarkedForDeletionVMI(nadName),
+			expectedResponse: reconcile.Result{},
+			existingIPAMClaim: &ipamclaimsapi.IPAMClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       fmt.Sprintf("%s.%s", vmName, "randomnet"),
+					Namespace:  namespace,
+					Finalizers: []string{kubevirtVMFinalizer},
+					Labels:     ownedByVMLabel(vmName),
+				},
+				Spec: ipamclaimsapi.IPAMClaimSpec{Network: "doesitmatter?"},
+			},
+			expectedIPAMClaims: []ipamclaimsapi.IPAMClaim{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "vm1.randomnet",
+						Namespace: "ns1",
+						Labels:    ownedByVMLabel(vmName),
+					},
+					Spec: ipamclaimsapi.IPAMClaimSpec{Network: "doesitmatter?"},
+				},
+			},
+		}),
+		Entry("standalone VMI which is marked for deletion, with active pods, should keep IPAMClaims finalizers", testConfig{
+			inputVMI:         dummyMarkedForDeletionVMIWithActivePods(nadName),
+			inputNAD:         dummyNAD(nadName),
+			expectedResponse: reconcile.Result{},
+			existingIPAMClaim: &ipamclaimsapi.IPAMClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       fmt.Sprintf("%s.%s", vmName, "randomnet"),
+					Namespace:  namespace,
+					Finalizers: []string{kubevirtVMFinalizer},
+					Labels:     ownedByVMLabel(vmName),
+					OwnerReferences: []metav1.OwnerReference{{
+						Name:               vmName,
+						UID:                dummyUID,
+						Kind:               "VirtualMachineInstance",
+						Controller:         ptr.To(true),
+						BlockOwnerDeletion: ptr.To(true),
+					}},
+				},
+				Spec: ipamclaimsapi.IPAMClaimSpec{Network: "doesitmatter?"},
+			},
+			expectedIPAMClaims: []ipamclaimsapi.IPAMClaim{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       "vm1.randomnet",
+						Namespace:  "ns1",
+						Finalizers: []string{kubevirtVMFinalizer},
+						Labels:     ownedByVMLabel(vmName),
+						OwnerReferences: []metav1.OwnerReference{{
+							Name:               vmName,
+							UID:                dummyUID,
+							Kind:               "VirtualMachineInstance",
+							Controller:         ptr.To(true),
+							BlockOwnerDeletion: ptr.To(true),
+						}},
+					},
+					Spec: ipamclaimsapi.IPAMClaimSpec{Network: "doesitmatter?"},
+				},
+			},
+		}),
+		Entry("VM which is marked for deletion, without VMI, thus IPAMClaims finalizers must be removed", testConfig{
+			inputVM:          dummyMarkedForDeletionVM(nadName),
 			expectedResponse: reconcile.Result{},
 			existingIPAMClaim: &ipamclaimsapi.IPAMClaim{
 				ObjectMeta: metav1.ObjectMeta{
@@ -293,11 +411,17 @@ var _ = Describe("vmi IPAM controller", Serial, func() {
 			expectedIPAMClaims: []ipamclaimsapi.IPAMClaim{
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:            "vm1.randomnet",
-						Namespace:       "ns1",
-						Labels:          ownedByVMLabel(vmName),
-						Finalizers:      []string{kubevirtVMFinalizer},
-						OwnerReferences: []metav1.OwnerReference{{Name: vmName}},
+						Name:       "vm1.randomnet",
+						Namespace:  "ns1",
+						Labels:     ownedByVMLabel(vmName),
+						Finalizers: []string{kubevirtVMFinalizer},
+						OwnerReferences: []metav1.OwnerReference{{
+							APIVersion:         "kubevirt.io/v1",
+							Kind:               "VirtualMachineInstance",
+							Name:               vmName,
+							Controller:         ptr.To(true),
+							BlockOwnerDeletion: ptr.To(true)},
+						},
 					},
 					Spec: ipamclaimsapi.IPAMClaimSpec{Network: "goodnet"},
 				},
@@ -308,6 +432,10 @@ var _ = Describe("vmi IPAM controller", Serial, func() {
 
 func dummyVM(vmiSpec virtv1.VirtualMachineInstanceSpec) *virtv1.VirtualMachine {
 	return &virtv1.VirtualMachine{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "kubevirt.io/v1",
+			Kind:       "VirtualMachine",
+		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "vm1",
 			Namespace: "ns1",
@@ -322,6 +450,10 @@ func dummyVM(vmiSpec virtv1.VirtualMachineInstanceSpec) *virtv1.VirtualMachine {
 
 func dummyVMI(vmiSpec virtv1.VirtualMachineInstanceSpec) *virtv1.VirtualMachineInstance {
 	return &virtv1.VirtualMachineInstance{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "kubevirt.io/v1",
+			Kind:       "VirtualMachineInstance",
+		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "vm1",
 			Namespace: "ns1",
@@ -402,3 +534,98 @@ func decorateVMWithUID(uid string, vm *virtv1.VirtualMachine) *virtv1.VirtualMac
 	vm.UID = apitypes.UID(uid)
 	return vm
 }
+func dummyMarkedForDeletionVMI(nadName string) *virtv1.VirtualMachineInstance {
+	vmi := dummyVMI(dummyVMISpec(nadName))
+	vmi.DeletionTimestamp = &metav1.Time{Time: time.Now()}
+	vmi.ObjectMeta.Finalizers = []string{metav1.FinalizerDeleteDependents}
+
+	return vmi
+}
+
+func dummyMarkedForDeletionVMIWithActivePods(nadName string) *virtv1.VirtualMachineInstance {
+	vmi := dummyVMI(dummyVMISpec(nadName))
+	vmi.DeletionTimestamp = &metav1.Time{Time: time.Now()}
+	vmi.ObjectMeta.Finalizers = []string{metav1.FinalizerDeleteDependents}
+
+	vmi.Status.ActivePods = map[apitypes.UID]string{"podUID": "dummyNodeName"}
+	vmi.UID = apitypes.UID(dummyUID)
+
+	return vmi
+}
+
+func dummyMarkedForDeletionVM(nadName string) *virtv1.VirtualMachine {
+	vm := dummyVM(dummyVMISpec(nadName))
+	vm.DeletionTimestamp = &metav1.Time{Time: time.Now()}
+	vm.ObjectMeta.Finalizers = []string{metav1.FinalizerDeleteDependents}
+
+	return vm
+}
+
+var _ = Describe("shouldCleanFinalizers", func() {
+	DescribeTable("should determine if finalizers should be cleaned up",
+		func(vmi *virtv1.VirtualMachineInstance, vm *virtv1.VirtualMachine, expectedResult bool) {
+			Expect(shouldCleanFinalizers(vmi, vm)).To(Equal(expectedResult))
+		},
+		Entry("VM exist, VMI gone, VM is marked for deletion",
+			nil,
+			&virtv1.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					DeletionTimestamp: &metav1.Time{Time: time.Now()},
+				},
+			},
+			true,
+		),
+		Entry("VM exist, VMI gone",
+			nil,
+			&virtv1.VirtualMachine{},
+			false,
+		),
+		Entry("VM exist, VMI exist",
+			&virtv1.VirtualMachineInstance{},
+			&virtv1.VirtualMachine{},
+			false),
+		Entry("VM exist, VMI exist, VM is marked for deletion",
+			&virtv1.VirtualMachineInstance{},
+			&virtv1.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					DeletionTimestamp: &metav1.Time{Time: time.Now()},
+				},
+			},
+			false,
+		),
+		Entry("standalone VMI is gone",
+			nil,
+			nil,
+			true,
+		),
+		Entry("standalone VMI, marked for deletion, without active pods",
+			&virtv1.VirtualMachineInstance{
+				ObjectMeta: metav1.ObjectMeta{
+					DeletionTimestamp: &metav1.Time{Time: time.Now()},
+				},
+				Status: virtv1.VirtualMachineInstanceStatus{
+					ActivePods: map[apitypes.UID]string{},
+				},
+			},
+			nil,
+			true,
+		),
+		Entry("standalone VMI exist",
+			&virtv1.VirtualMachineInstance{},
+			nil,
+			false,
+		),
+		Entry("standalone VMI, marked for deletion, with ActivePods",
+			&virtv1.VirtualMachineInstance{
+				ObjectMeta: metav1.ObjectMeta{
+					DeletionTimestamp: &metav1.Time{Time: time.Now()},
+				},
+				Status: virtv1.VirtualMachineInstanceStatus{
+					ActivePods: map[apitypes.UID]string{"uid": "node_name"},
+				},
+			},
+			nil,
+			false,
+		),
+	)
+})

--- a/pkg/vmnetworkscontroller/vm_controller.go
+++ b/pkg/vmnetworkscontroller/vm_controller.go
@@ -1,0 +1,99 @@
+package vmnetworkscontroller
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/kubevirt/ipam-extensions/pkg/claims"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	controllerruntime "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	virtv1 "kubevirt.io/api/core/v1"
+)
+
+// VirtualMachineReconciler reconciles a VirtualMachine object
+type VirtualMachineReconciler struct {
+	client.Client
+	Log     logr.Logger
+	Scheme  *runtime.Scheme
+	manager controllerruntime.Manager
+}
+
+func NewVMReconciler(manager controllerruntime.Manager) *VirtualMachineReconciler {
+	return &VirtualMachineReconciler{
+		Client:  manager.GetClient(),
+		Log:     controllerruntime.Log.WithName("controllers").WithName("VirtualMachine"),
+		Scheme:  manager.GetScheme(),
+		manager: manager,
+	}
+}
+
+func (r *VirtualMachineReconciler) Reconcile(
+	ctx context.Context,
+	request controllerruntime.Request,
+) (controllerruntime.Result, error) {
+	vm := &virtv1.VirtualMachine{}
+	contextWithTimeout, cancel := context.WithTimeout(ctx, time.Second)
+	defer cancel()
+
+	shouldRemoveFinalizer := false
+	err := r.Client.Get(contextWithTimeout, request.NamespacedName, vm)
+	if apierrors.IsNotFound(err) {
+		shouldRemoveFinalizer = true
+	} else if err != nil {
+		return controllerruntime.Result{}, err
+	}
+
+	if vm.DeletionTimestamp != nil {
+		vmi := &virtv1.VirtualMachineInstance{}
+		contextWithTimeout, cancel := context.WithTimeout(ctx, time.Second)
+		defer cancel()
+		err := r.Client.Get(contextWithTimeout, request.NamespacedName, vmi)
+		if apierrors.IsNotFound(err) {
+			shouldRemoveFinalizer = true
+		} else if err != nil {
+			return controllerruntime.Result{}, err
+		}
+	}
+
+	if shouldRemoveFinalizer {
+		if err := claims.Cleanup(r.Client, request.NamespacedName); err != nil {
+			return controllerruntime.Result{}, fmt.Errorf("failed removing the IPAMClaims finalizer: %w", err)
+		}
+	}
+
+	return controllerruntime.Result{}, nil
+}
+
+// Setup sets up the controller with the Manager passed in the constructor.
+func (r *VirtualMachineReconciler) Setup() error {
+	return controllerruntime.NewControllerManagedBy(r.manager).
+		For(&virtv1.VirtualMachine{}).
+		WithEventFilter(onVMPredicates()).
+		Complete(r)
+}
+
+func onVMPredicates() predicate.Funcs {
+	return predicate.Funcs{
+		CreateFunc: func(createEvent event.CreateEvent) bool {
+			return false
+		},
+		DeleteFunc: func(event.DeleteEvent) bool {
+			return true
+		},
+		UpdateFunc: func(updateEvent event.UpdateEvent) bool {
+			return true
+		},
+		GenericFunc: func(event.GenericEvent) bool {
+			return false
+		},
+	}
+}

--- a/pkg/vmnetworkscontroller/vm_controller_test.go
+++ b/pkg/vmnetworkscontroller/vm_controller_test.go
@@ -1,0 +1,246 @@
+package vmnetworkscontroller_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	virtv1 "kubevirt.io/api/core/v1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apitypes "k8s.io/apimachinery/pkg/types"
+
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+
+	"k8s.io/utils/ptr"
+
+	controllerruntime "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	ipamclaimsapi "github.com/k8snetworkplumbingwg/ipamclaims/pkg/crd/ipamclaims/v1alpha1"
+	nadv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+
+	"github.com/kubevirt/ipam-extensions/pkg/claims"
+	"github.com/kubevirt/ipam-extensions/pkg/vmnetworkscontroller"
+)
+
+func TestController(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "VM Controller test suite")
+}
+
+type testConfig struct {
+	inputVM            *virtv1.VirtualMachine
+	inputVMI           *virtv1.VirtualMachineInstance
+	existingIPAMClaim  *ipamclaimsapi.IPAMClaim
+	expectedError      error
+	expectedResponse   reconcile.Result
+	expectedIPAMClaims []ipamclaimsapi.IPAMClaim
+}
+
+var (
+	testEnv *envtest.Environment
+)
+
+var _ = Describe("VM IPAM controller", Serial, func() {
+	BeforeEach(func() {
+		log.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+		testEnv = &envtest.Environment{}
+		_, err := testEnv.Start()
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(virtv1.AddToScheme(scheme.Scheme)).To(Succeed())
+		Expect(nadv1.AddToScheme(scheme.Scheme)).To(Succeed())
+		Expect(ipamclaimsapi.AddToScheme(scheme.Scheme)).To(Succeed())
+		// +kubebuilder:scaffold:scheme
+	})
+
+	AfterEach(func() {
+		Expect(testEnv.Stop()).To(Succeed())
+	})
+
+	const (
+		nadName   = "ns1/superdupernad"
+		namespace = "ns1"
+		vmName    = "vm1"
+	)
+
+	DescribeTable("reconcile behavior is as expected", func(config testConfig) {
+		var initialObjects []client.Object
+
+		var vmKey apitypes.NamespacedName
+		if config.inputVM != nil {
+			vmKey = apitypes.NamespacedName{
+				Namespace: config.inputVM.Namespace,
+				Name:      config.inputVM.Name,
+			}
+			initialObjects = append(initialObjects, config.inputVM)
+		}
+
+		if config.inputVMI != nil {
+			initialObjects = append(initialObjects, config.inputVMI)
+		}
+
+		if config.existingIPAMClaim != nil {
+			initialObjects = append(initialObjects, config.existingIPAMClaim)
+		}
+
+		if vmKey.Namespace == "" && vmKey.Name == "" {
+			vmKey = apitypes.NamespacedName{
+				Namespace: namespace,
+				Name:      vmName,
+			}
+		}
+
+		ctrlOptions := controllerruntime.Options{
+			Scheme: scheme.Scheme,
+			NewClient: func(_ *rest.Config, _ client.Options) (client.Client, error) {
+				return fake.NewClientBuilder().
+					WithScheme(scheme.Scheme).
+					WithObjects(initialObjects...).
+					Build(), nil
+			},
+		}
+
+		mgr, err := controllerruntime.NewManager(&rest.Config{}, ctrlOptions)
+		Expect(err).NotTo(HaveOccurred())
+
+		reconcileVM := vmnetworkscontroller.NewVMReconciler(mgr)
+		if config.expectedError != nil {
+			_, err := reconcileVM.Reconcile(context.Background(), controllerruntime.Request{NamespacedName: vmKey})
+			Expect(err).To(MatchError(config.expectedError))
+		} else {
+			Expect(
+				reconcileVM.Reconcile(context.Background(), controllerruntime.Request{NamespacedName: vmKey}),
+			).To(Equal(config.expectedResponse))
+		}
+
+		if len(config.expectedIPAMClaims) > 0 {
+			ipamClaimList := &ipamclaimsapi.IPAMClaimList{}
+
+			Expect(mgr.GetClient().List(context.Background(), ipamClaimList, claims.OwnedByVMLabel(vmName))).To(Succeed())
+			Expect(ipamClaimsCleaner(ipamClaimList.Items...)).To(ConsistOf(config.expectedIPAMClaims))
+		}
+	},
+		Entry("when the VM is marked for deletion and its VMI is gone", testConfig{
+			inputVM:           dummyMarkedForDeletionVM(nadName),
+			inputVMI:          nil,
+			existingIPAMClaim: dummyIPAMClaimWithFinalizer(namespace, vmName),
+			expectedResponse:  reconcile.Result{},
+			expectedIPAMClaims: []ipamclaimsapi.IPAMClaim{
+				*dummyIPAMClaimmWithoutFinalizer(namespace, vmName),
+			},
+		}),
+		Entry("when the VM is gone", testConfig{
+			inputVM:           nil,
+			inputVMI:          nil,
+			existingIPAMClaim: dummyIPAMClaimWithFinalizer(namespace, vmName),
+			expectedResponse:  reconcile.Result{},
+			expectedIPAMClaims: []ipamclaimsapi.IPAMClaim{
+				*dummyIPAMClaimmWithoutFinalizer(namespace, vmName),
+			},
+		}),
+		Entry("when the VM is marked for deletion and its VMI still exist", testConfig{
+			inputVM:           dummyMarkedForDeletionVM(nadName),
+			inputVMI:          dummyVMI(nadName),
+			existingIPAMClaim: dummyIPAMClaimWithFinalizer(namespace, vmName),
+			expectedResponse:  reconcile.Result{},
+			expectedIPAMClaims: []ipamclaimsapi.IPAMClaim{
+				*dummyIPAMClaimWithFinalizer(namespace, vmName),
+			},
+		}),
+	)
+})
+
+func dummyMarkedForDeletionVM(nadName string) *virtv1.VirtualMachine {
+	vm := dummyVM(nadName)
+	vm.DeletionTimestamp = &metav1.Time{Time: time.Now()}
+	vm.ObjectMeta.Finalizers = []string{metav1.FinalizerDeleteDependents}
+
+	return vm
+}
+
+func dummyVM(nadName string) *virtv1.VirtualMachine {
+	return &virtv1.VirtualMachine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "vm1",
+			Namespace: "ns1",
+		},
+		Spec: virtv1.VirtualMachineSpec{
+			Template: &virtv1.VirtualMachineInstanceTemplateSpec{
+				Spec: dummyVMISpec(nadName),
+			},
+		},
+	}
+}
+
+func dummyVMI(nadName string) *virtv1.VirtualMachineInstance {
+	return &virtv1.VirtualMachineInstance{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "vm1",
+			Namespace: "ns1",
+		},
+		Spec: dummyVMISpec(nadName),
+	}
+}
+
+func dummyVMISpec(nadName string) virtv1.VirtualMachineInstanceSpec {
+	return virtv1.VirtualMachineInstanceSpec{
+		Networks: []virtv1.Network{
+			{
+				Name:          "podnet",
+				NetworkSource: virtv1.NetworkSource{Pod: &virtv1.PodNetwork{}},
+			},
+			{
+				Name: "randomnet",
+				NetworkSource: virtv1.NetworkSource{
+					Multus: &virtv1.MultusNetwork{
+						NetworkName: nadName,
+					},
+				},
+			},
+		},
+	}
+}
+
+func ipamClaimsCleaner(ipamClaims ...ipamclaimsapi.IPAMClaim) []ipamclaimsapi.IPAMClaim {
+	for i := range ipamClaims {
+		ipamClaims[i].ObjectMeta.ResourceVersion = ""
+	}
+	return ipamClaims
+}
+
+func dummyIPAMClaimWithFinalizer(namespace, vmName string) *ipamclaimsapi.IPAMClaim {
+	ipamClaim := dummyIPAMClaimmWithoutFinalizer(namespace, vmName)
+	ipamClaim.Finalizers = []string{claims.KubevirtVMFinalizer}
+	return ipamClaim
+}
+
+func dummyIPAMClaimmWithoutFinalizer(namespace, vmName string) *ipamclaimsapi.IPAMClaim {
+	return &ipamclaimsapi.IPAMClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%s.%s", vmName, "randomnet"),
+			Namespace: namespace,
+			Labels:    claims.OwnedByVMLabel(vmName),
+			OwnerReferences: []metav1.OwnerReference{{
+				Name:               vmName,
+				Kind:               "VirtualMachine",
+				Controller:         ptr.To(true),
+				BlockOwnerDeletion: ptr.To(true),
+			}},
+		},
+		Spec: ipamclaimsapi.IPAMClaimSpec{
+			Network: "goodnet",
+		},
+	}
+}

--- a/test/env/matcher.go
+++ b/test/env/matcher.go
@@ -72,6 +72,22 @@ func BeRestarted(oldUID types.UID) gomegatypes.GomegaMatcher {
 	}))
 }
 
+func BeCreated() gomegatypes.GomegaMatcher {
+	return gstruct.PointTo(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+		"Status": gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+			"Created": BeTrue(),
+		}),
+	}))
+}
+
+func BeReady() gomegatypes.GomegaMatcher {
+	return gstruct.PointTo(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+		"Status": gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+			"Ready": BeTrue(),
+		}),
+	}))
+}
+
 func ContainConditionVMIReady() gomegatypes.GomegaMatcher {
 	return WithTransform(vmiStatusConditions,
 		ContainElement(SatisfyAll(

--- a/test/env/matcher.go
+++ b/test/env/matcher.go
@@ -12,6 +12,8 @@ import (
 
 	kubevirtv1 "kubevirt.io/api/core/v1"
 
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
 	ipamclaimsv1alpha1 "github.com/k8snetworkplumbingwg/ipamclaims/pkg/crd/ipamclaims/v1alpha1"
 )
 
@@ -19,7 +21,7 @@ import (
 func IPAMClaimsFromNamespace(namespace string) func() ([]ipamclaimsv1alpha1.IPAMClaim, error) {
 	return func() ([]ipamclaimsv1alpha1.IPAMClaim, error) {
 		ipamClaimList := &ipamclaimsv1alpha1.IPAMClaimList{}
-		if err := Client.List(context.Background(), ipamClaimList); err != nil {
+		if err := Client.List(context.Background(), ipamClaimList, client.InNamespace(namespace)); err != nil {
 			return nil, err
 		}
 		return ipamClaimList.Items, nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Remove the finalizer from the ipam claim on the following cases:

VMI events:
1. VM that is marked for deletion, and its VMI is gone.
2. Standalone VMI, that is marked for deletion, and it's virt-launcher is gone.
3. Standalone VMI that was deleted.

VM events:
1. VM is deleted (happens on background delete).
2. VM is marked for deletion, and the VMI is deleted (foreground delete).

(might remind VMI events, but it can happen for stopped VM so we should handle
it as well as VM event).

Changes beside that:
1. Add missing `BlockOwnerDeletion` that affects foreground delete.
Owner which is either VM or VMI, will be deleted only after the
owned ipam claim is deleted.
We remove the finalizer from the ipam claim, once the claim is ready to be deleted.
2. Add missing `Controller` field, since the claims are created by this controller.
3. Fix `IPAMClaimsFromNamespace` to list claims only per given namespace.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
A follow-up PR that upon controller restart, we look for dangling claims
and remove their finalizer. For example if a VM was deleted while controller was down.
Controller will restart, and won't get event on the VM that was deleted, because it gets info about the current
cluster state. Therefore we should clean finalizer from those orphan ipam claims.
PR: https://github.com/kubevirt/ipam-extensions/pull/48

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
5. If no release note is required, just write "NONE".
-->
```release-note

```
