### PR TITLE
WIP: (dont review) Try to research a failure

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -46,6 +46,7 @@ import (
 
 	"github.com/kubevirt/ipam-extensions/pkg/ipamclaimswebhook"
 	"github.com/kubevirt/ipam-extensions/pkg/vminetworkscontroller"
+	"github.com/kubevirt/ipam-extensions/pkg/vmnetworkscontroller"
 	//+kubebuilder:scaffold:imports
 )
 
@@ -153,6 +154,11 @@ func main() {
 	}
 	if err := mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
 		setupLog.Error(err, "unable to set up ready check")
+		os.Exit(1)
+	}
+
+	if err = vmnetworkscontroller.NewVMReconciler(mgr).Setup(); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "VirtualMachine")
 		os.Exit(1)
 	}
 

--- a/pkg/claims/claims.go
+++ b/pkg/claims/claims.go
@@ -1,0 +1,44 @@
+package claims
+
+import (
+	"context"
+	"fmt"
+
+	apitypes "k8s.io/apimachinery/pkg/types"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	ipamclaimsapi "github.com/k8snetworkplumbingwg/ipamclaims/pkg/crd/ipamclaims/v1alpha1"
+
+	virtv1 "kubevirt.io/api/core/v1"
+)
+
+const KubevirtVMFinalizer = "kubevirt.io/persistent-ipam"
+
+func Cleanup(c client.Client, vmiKey apitypes.NamespacedName) error {
+	ipamClaims := &ipamclaimsapi.IPAMClaimList{}
+	listOpts := []client.ListOption{
+		client.InNamespace(vmiKey.Namespace),
+		OwnedByVMLabel(vmiKey.Name),
+	}
+	if err := c.List(context.Background(), ipamClaims, listOpts...); err != nil {
+		return fmt.Errorf("could not get list of IPAMClaims owned by VM %q: %w", vmiKey.String(), err)
+	}
+
+	for _, claim := range ipamClaims.Items {
+		removedFinalizer := controllerutil.RemoveFinalizer(&claim, KubevirtVMFinalizer)
+		if removedFinalizer {
+			if err := c.Update(context.Background(), &claim, &client.UpdateOptions{}); err != nil {
+				return client.IgnoreNotFound(err)
+			}
+		}
+	}
+	return nil
+}
+
+func OwnedByVMLabel(vmiName string) client.MatchingLabels {
+	return map[string]string{
+		virtv1.VirtualMachineLabel: vmiName,
+	}
+}

--- a/pkg/vminetworkscontroller/vmi_controller_test.go
+++ b/pkg/vminetworkscontroller/vmi_controller_test.go
@@ -27,11 +27,13 @@ import (
 
 	ipamclaimsapi "github.com/k8snetworkplumbingwg/ipamclaims/pkg/crd/ipamclaims/v1alpha1"
 	nadv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+
+	"github.com/kubevirt/ipam-extensions/pkg/claims"
 )
 
 func TestController(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Controller test suite")
+	RunSpecs(t, "VMI Controller test suite")
 }
 
 var (
@@ -48,7 +50,7 @@ type testConfig struct {
 	expectedIPAMClaims []ipamclaimsapi.IPAMClaim
 }
 
-var _ = Describe("vmi IPAM controller", Serial, func() {
+var _ = Describe("VMI IPAM controller", Serial, func() {
 	BeforeEach(func() {
 		log.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 		testEnv = &envtest.Environment{}
@@ -131,7 +133,7 @@ var _ = Describe("vmi IPAM controller", Serial, func() {
 		if len(config.expectedIPAMClaims) > 0 {
 			ipamClaimList := &ipamclaimsapi.IPAMClaimList{}
 
-			Expect(mgr.GetClient().List(context.Background(), ipamClaimList, ownedByVMLabel(vmName))).To(Succeed())
+			Expect(mgr.GetClient().List(context.Background(), ipamClaimList, claims.OwnedByVMLabel(vmName))).To(Succeed())
 			Expect(ipamClaimsCleaner(ipamClaimList.Items...)).To(ConsistOf(config.expectedIPAMClaims))
 		}
 	},
@@ -145,8 +147,8 @@ var _ = Describe("vmi IPAM controller", Serial, func() {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            fmt.Sprintf("%s.%s", vmName, "randomnet"),
 						Namespace:       namespace,
-						Finalizers:      []string{kubevirtVMFinalizer},
-						Labels:          ownedByVMLabel(vmName),
+						Finalizers:      []string{claims.KubevirtVMFinalizer},
+						Labels:          claims.OwnedByVMLabel(vmName),
 						OwnerReferences: []metav1.OwnerReference{{Name: vmName}},
 					},
 					Spec: ipamclaimsapi.IPAMClaimSpec{Network: "goodnet"},
@@ -185,8 +187,8 @@ var _ = Describe("vmi IPAM controller", Serial, func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       fmt.Sprintf("%s.%s", vmName, "randomnet"),
 					Namespace:  namespace,
-					Finalizers: []string{kubevirtVMFinalizer},
-					Labels:     ownedByVMLabel(vmName),
+					Finalizers: []string{claims.KubevirtVMFinalizer},
+					Labels:     claims.OwnedByVMLabel(vmName),
 				},
 				Spec: ipamclaimsapi.IPAMClaimSpec{Network: "doesitmatter?"},
 			},
@@ -195,7 +197,7 @@ var _ = Describe("vmi IPAM controller", Serial, func() {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "vm1.randomnet",
 						Namespace: "ns1",
-						Labels:    ownedByVMLabel(vmName),
+						Labels:    claims.OwnedByVMLabel(vmName),
 					},
 					Spec: ipamclaimsapi.IPAMClaimSpec{Network: "doesitmatter?"},
 				},
@@ -230,8 +232,8 @@ var _ = Describe("vmi IPAM controller", Serial, func() {
 							UID:        dummyUID,
 						},
 					},
-					Labels:     ownedByVMLabel(vmName),
-					Finalizers: []string{kubevirtVMFinalizer},
+					Labels:     claims.OwnedByVMLabel(vmName),
+					Finalizers: []string{claims.KubevirtVMFinalizer},
 				},
 				Spec: ipamclaimsapi.IPAMClaimSpec{Network: "doesitmatter?"},
 			},
@@ -241,7 +243,7 @@ var _ = Describe("vmi IPAM controller", Serial, func() {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "vm1.randomnet",
 						Namespace: "ns1",
-						Labels:    ownedByVMLabel(vmName),
+						Labels:    claims.OwnedByVMLabel(vmName),
 						OwnerReferences: []metav1.OwnerReference{
 							{
 								APIVersion: "v1",
@@ -250,7 +252,7 @@ var _ = Describe("vmi IPAM controller", Serial, func() {
 								UID:        dummyUID,
 							},
 						},
-						Finalizers: []string{kubevirtVMFinalizer},
+						Finalizers: []string{claims.KubevirtVMFinalizer},
 					},
 					Spec: ipamclaimsapi.IPAMClaimSpec{Network: "doesitmatter?"},
 				},
@@ -272,8 +274,8 @@ var _ = Describe("vmi IPAM controller", Serial, func() {
 							UID:        unexpectedUID,
 						},
 					},
-					Labels:     ownedByVMLabel(vmName),
-					Finalizers: []string{kubevirtVMFinalizer},
+					Labels:     claims.OwnedByVMLabel(vmName),
+					Finalizers: []string{claims.KubevirtVMFinalizer},
 				},
 				Spec: ipamclaimsapi.IPAMClaimSpec{Network: "doesitmatter?"},
 			},
@@ -288,8 +290,8 @@ var _ = Describe("vmi IPAM controller", Serial, func() {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "vm1.randomnet",
 						Namespace:       "ns1",
-						Labels:          ownedByVMLabel(vmName),
-						Finalizers:      []string{kubevirtVMFinalizer},
+						Labels:          claims.OwnedByVMLabel(vmName),
+						Finalizers:      []string{claims.KubevirtVMFinalizer},
 						OwnerReferences: []metav1.OwnerReference{{Name: vmName}},
 					},
 					Spec: ipamclaimsapi.IPAMClaimSpec{Network: "goodnet"},

--- a/pkg/vmnetworkscontroller/vm_controller.go
+++ b/pkg/vmnetworkscontroller/vm_controller.go
@@ -1,0 +1,99 @@
+package vmnetworkscontroller
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/kubevirt/ipam-extensions/pkg/claims"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	controllerruntime "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	virtv1 "kubevirt.io/api/core/v1"
+)
+
+// VirtualMachineReconciler reconciles a VirtualMachine object
+type VirtualMachineReconciler struct {
+	client.Client
+	Log     logr.Logger
+	Scheme  *runtime.Scheme
+	manager controllerruntime.Manager
+}
+
+func NewVMReconciler(manager controllerruntime.Manager) *VirtualMachineReconciler {
+	return &VirtualMachineReconciler{
+		Client:  manager.GetClient(),
+		Log:     controllerruntime.Log.WithName("controllers").WithName("VirtualMachine"),
+		Scheme:  manager.GetScheme(),
+		manager: manager,
+	}
+}
+
+func (r *VirtualMachineReconciler) Reconcile(
+	ctx context.Context,
+	request controllerruntime.Request,
+) (controllerruntime.Result, error) {
+	vm := &virtv1.VirtualMachine{}
+	contextWithTimeout, cancel := context.WithTimeout(ctx, time.Second)
+	defer cancel()
+
+	shouldRemoveFinalizer := false
+	err := r.Client.Get(contextWithTimeout, request.NamespacedName, vm)
+	if apierrors.IsNotFound(err) {
+		shouldRemoveFinalizer = true
+	} else if err != nil {
+		return controllerruntime.Result{}, err
+	}
+
+	if vm.DeletionTimestamp != nil {
+		vmi := &virtv1.VirtualMachineInstance{}
+		contextWithTimeout, cancel := context.WithTimeout(ctx, time.Second)
+		defer cancel()
+		err := r.Client.Get(contextWithTimeout, request.NamespacedName, vmi)
+		if apierrors.IsNotFound(err) {
+			shouldRemoveFinalizer = true
+		} else if err != nil {
+			return controllerruntime.Result{}, err
+		}
+	}
+
+	if shouldRemoveFinalizer {
+		if err := claims.Cleanup(r.Client, request.NamespacedName); err != nil {
+			return controllerruntime.Result{}, fmt.Errorf("error removing the IPAMClaims finalizer: %w", err)
+		}
+	}
+
+	return controllerruntime.Result{}, nil
+}
+
+// Setup sets up the controller with the Manager passed in the constructor.
+func (r *VirtualMachineReconciler) Setup() error {
+	return controllerruntime.NewControllerManagedBy(r.manager).
+		For(&virtv1.VirtualMachine{}).
+		WithEventFilter(onVMPredicates()).
+		Complete(r)
+}
+
+func onVMPredicates() predicate.Funcs {
+	return predicate.Funcs{
+		CreateFunc: func(createEvent event.CreateEvent) bool {
+			return false
+		},
+		DeleteFunc: func(event.DeleteEvent) bool {
+			return true
+		},
+		UpdateFunc: func(updateEvent event.UpdateEvent) bool {
+			return true
+		},
+		GenericFunc: func(event.GenericEvent) bool {
+			return false
+		},
+	}
+}

--- a/pkg/vmnetworkscontroller/vm_controller_test.go
+++ b/pkg/vmnetworkscontroller/vm_controller_test.go
@@ -1,0 +1,17 @@
+package vmnetworkscontroller
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestController(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "VM Controller test suite")
+}
+
+var _ = Describe("VM IPAM controller", Serial, func() {
+
+})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Doing a naive change, cause first test to fail, unless we first wait for the component to be
fully deployed.
Lets try to at least understand what happens first.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
