### PR TITLE
Add missing rbacs

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -18,6 +18,11 @@ rules:
   - "virtualmachines"
   - "virtualmachineinstances"
   verbs: ["get", "list", "watch"]
+- apiGroups: ["kubevirt.io"]
+  resources:
+  - "virtualmachines/finalizers"
+  - "virtualmachineinstances/finalizers"
+  verbs: ["update"]
 - apiGroups: ["k8s.cni.cncf.io"]
   resources:
       - ipamclaims

--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -104,6 +104,13 @@ rules:
   - list
   - watch
 - apiGroups:
+  - kubevirt.io
+  resources:
+  - virtualmachines/finalizers
+  - virtualmachineinstances/finalizers
+  verbs:
+  - update
+- apiGroups:
   - k8s.cni.cncf.io
   resources:
   - ipamclaims


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Lately `blockOwnerDeletion` was added (finalizer fix PR).
On OpenShift there is an additional protection, that setting `blockOwnerDeletion` requires
to be able to set finalizers on the owner.
The owner might be either VM or VMI.
Add the missing rbacs.

```
2024-08-11T10:41:43Z	ERROR	Reconciler error	{"controller": "virtualmachineinstance", "controllerGroup": "kubevirt.io", "controllerKind": "VirtualMachineInstance", "VirtualMachineInstance": {"name":"vma-localnet-ipam-medium-pool","namespace":"localnet-ipam"}, "namespace": "localnet-ipam", "name": "vma-localnet-ipam-medium-pool", "reconcileID": "9d6cb8f1-87be-410b-8b92-3efce065cd2d", "error": "ipamclaims.k8s.cni.cncf.io \"vma-localnet-ipam-medium-pool.ipam-network\" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>"}
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#ownerreferencespermissionenforcement

Seems it will be good to enable `OwnerReferencesPermissionEnforcement` on kind,
https://github.com/ovn-org/ovn-kubernetes/pull/4608
For now just used it to make sure i can simulate the bug on kind, and that this PR does solve it.

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
