### PR TITLE
WIP: Primary udn integration

### DIFF
--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -8,6 +8,7 @@ import (
 type RelevantConfig struct {
 	Name               string `json:"name"`
 	AllowPersistentIPs bool   `json:"allowPersistentIPs,omitempty"`
+	Role               string `json:"role,omitempty"`
 }
 
 func NewConfig(nadSpec string) (*RelevantConfig, error) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR instructs OVN-K of the IPAMClaim name to be used for the primary UDN feature.

We could have hard-coded instead the name, but then, we would need to understand which workload really wants persistent IPs on OVN-K - i.e. it would have to identify if it is allocating for a VM or a pod.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
WIP. PLEASE DO NOT merge.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Integrate with the primary user defined network OVN-Kubernetes feature.
```

