### PR TITLE
Allow setting custom KUBECONFIG

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,8 @@
 IMG ?= kubevirt-ipam-controller:latest
 PASST_IMG ?= kubevirt/passt-binding-cni:latest
 
+export KUBECONFIG ?= $(shell pwd)/.output/kubeconfig
+
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.29.0
 
@@ -72,7 +74,7 @@ test: manifests generate fmt vet envtest ## Run tests.
 # Utilize Kind or modify the e2e tests to load the image locally, enabling compatibility with other vendors.
 .PHONY: test-e2e  # Run the e2e tests against a Kind k8s instance that is spun up.
 test-e2e:
-	export KUBECONFIG=$$(pwd)/.output/kubeconfig && \
+	export KUBECONFIG=${KUBECONFIG} && \
 	export PATH=$$(pwd)/.output/ovn-kubernetes/bin:$${PATH} && \
 	export REPORT_PATH=$$(pwd)/.output/ && \
 	cd test/e2e && \

--- a/hack/cluster.sh
+++ b/hack/cluster.sh
@@ -14,7 +14,7 @@ OVN_KUBERNETES_DIR=${OUTPUT_DIR}/ovn-kubernetes
 # from https://github.com/kubernetes-sigs/kind/releases
 KIND_BIN=${OUTPUT_DIR}/kind
 
-export KUBECONFIG=${OUTPUT_DIR}/kubeconfig
+export KUBECONFIG=${KUBECONFIG:-${OUTPUT_DIR}/kubeconfig}
 
 cluster_name=virt-ipam
 op=$1


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
In order to allow `cluster-sync` for providers that were not
created by the default scripts in this repo,
allow setting custom `KUBECONFIG` which is all needed
for `cluster-sync` and `test-e2e` targets.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

