### PR TITLE
cluster-sync: Use rollout instead of wait

### DIFF
--- a/hack/cluster.sh
+++ b/hack/cluster.sh
@@ -74,7 +74,7 @@ function sync() {
     # Generate the manifest with the "sha256" to force kubernetes to reload the image
     sha=$(skopeo inspect --tls-verify=false docker://$img:$tag |jq -r .Digest)
     IMG=$img@$sha make deploy
-    ${KUBECTL} wait -n kubevirt-ipam-controller-system deployment kubevirt-ipam-controller-manager --for condition=Available --timeout 2m
+    ${KUBECTL} rollout status -w -n kubevirt-ipam-controller-system deployment kubevirt-ipam-controller-manager --timeout 2m
 }
 
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Use rollout instead of wait at `make cluster-sync`

**Which issue(s) this PR fixes** 
Fixes #61

```release-note
NONE
```

