### PR TITLE
udn: rename the annotation used

### DIFF
--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -11,7 +11,7 @@ const (
 	NetworkRolePrimary NetworkRole = "primary"
 )
 
-const OVNPrimaryNetworkIPAMClaimAnnotation = "k8s.ovn.org/ovn-udn-ipamclaim-reference"
+const OVNPrimaryNetworkIPAMClaimAnnotation = "k8s.ovn.org/primary-udn-ipamclaim"
 
 type RelevantConfig struct {
 	Name               string      `json:"name"`

--- a/pkg/ipamclaimswebhook/podmutator_test.go
+++ b/pkg/ipamclaimswebhook/podmutator_test.go
@@ -146,7 +146,7 @@ var _ = Describe("KubeVirt IPAM launcher pod mutato machine", Serial, func() {
 				Patches: []jsonpatch.JsonPatchOperation{
 					{
 						Operation: "add",
-						Path:      "/metadata/annotations/k8s.ovn.org~1ovn-udn-ipamclaim-reference",
+						Path:      "/metadata/annotations/k8s.ovn.org~1primary-udn-ipamclaim",
 						Value:     "vm1.podnet",
 					},
 					{
@@ -173,7 +173,7 @@ var _ = Describe("KubeVirt IPAM launcher pod mutato machine", Serial, func() {
 				Patches: []jsonpatch.JsonPatchOperation{
 					{
 						Operation: "add",
-						Path:      "/metadata/annotations/k8s.ovn.org~1ovn-udn-ipamclaim-reference",
+						Path:      "/metadata/annotations/k8s.ovn.org~1primary-udn-ipamclaim",
 						Value:     "vm1.podnet",
 					},
 				},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR renames the annotation used to match the annotation expected [in this OVN-Kubernetes PR](https://github.com/ovn-org/ovn-kubernetes/pull/4651/).

In the future, we may actually use a label, and this name might change.

We expect to define this in this [OpenShift enhancement](https://github.com/openshift/enhancements/pull/1673).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

