### PR TITLE
UDN, IPAM: Use v1.multus-cni.io/default-network

### DIFF
--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -11,7 +11,10 @@ const (
 	NetworkRolePrimary NetworkRole = "primary"
 )
 
-const OVNPrimaryNetworkIPAMClaimAnnotation = "k8s.ovn.org/primary-udn-ipamclaim"
+const (
+	MultusDefaultNetwork = "v1.multus-cni.io/default-network"
+	DefaultNetworkName   = "ovn-kubernetes"
+)
 
 type RelevantConfig struct {
 	Name               string      `json:"name"`


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
In order to specify ipam-claim-reference for the primary network,
use `v1.multus-cni.io/default-network` instead
`k8s.ovn.org/primary-udn-ipamclaim`.

Webhook adds
`v1.multus-cni.io/default-network: '[{"namespace":"default","name":"ovn-kubernetes","ipam-claim-reference":"vm-a.passtnet"}]'`
(`ipam-claim-reference` value is dynamic of course)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
OVN K8s PR 
https://github.com/ovn-org/ovn-kubernetes/pull/4732
Both PRs need to be merged else the tests (that atm exists only on OVN) will break.
We should not merge it until the above PR is merge candid.

Need to create this NAD (because default-network points to a NAD):
based on `/etc/cni/net.d/10-ovn-kubernetes.conf`

```
cat <<EOF | oc apply -f -
apiVersion: "k8s.cni.cncf.io/v1"
kind: NetworkAttachmentDefinition
metadata:
  name: ovn-kubernetes
spec:
  config: '{
    "cniVersion": "0.4.0",
    "name": "ovn-kubernetes",
    "type": "ovn-k8s-cni-overlay",
    "ipam": {},
    "dns": {},
    "runtimeConfig": {}
  }'
EOF
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

