### PR TITLE
UDN: Use managedTap instead passt

### DIFF
--- a/test/e2e/persistentips_test.go
+++ b/test/e2e/persistentips_test.go
@@ -322,7 +322,7 @@ var _ = DescribeTableSubtree("Persistent IPs", func(params testParams) {
 		testParams{
 			role:    rolePrimary,
 			ipsFrom: defaultNetworkStatusAnnotationIPs,
-			vmi:     vmiWithPasst,
+			vmi:     vmiWithManagedTap,
 		}),
 )
 
@@ -378,9 +378,9 @@ func vmiWithMultus(namespace string) *kubevirtv1.VirtualMachineInstance {
 	)
 }
 
-func vmiWithPasst(namespace string) *kubevirtv1.VirtualMachineInstance {
+func vmiWithManagedTap(namespace string) *kubevirtv1.VirtualMachineInstance {
 	const (
-		interfaceName        = "passtnet"
+		interfaceName        = "pod"
 		cloudInitNetworkData = `
 version: 2
 ethernets:
@@ -389,11 +389,11 @@ ethernets:
 	)
 	return testenv.NewVirtualMachineInstance(
 		namespace,
-		testenv.WithMemory("2048Mi"),
+		testenv.WithMemory("1024Mi"),
 		testenv.WithInterface(kubevirtv1.Interface{
 			Name: interfaceName,
 			Binding: &kubevirtv1.PluginBinding{
-				Name: "passt",
+				Name: "managedTap",
 			},
 		}),
 		testenv.WithNetwork(kubevirtv1.Network{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Use `managedTap` binding instead `Passt` for primary UDN.
It is registered as part of OVN kind.sh that we use in this repo to spin the cluster.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Currently only IPv4 is supported.
A follow-up will add IPv6 support, by adding it to cloud-init, and deploying a dual stack cluster.
Once OVN use `l2bridge` naming we will adapt as well.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

