### PR TITLE
e2e, persistent-ip: Unify primary,secondary tests (primary UDNs use managedTap)

### DIFF
--- a/test/env/getter.go
+++ b/test/env/getter.go
@@ -2,12 +2,7 @@ package env
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
 
-	nadv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
-
-	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -50,76 +45,4 @@ func GetIPsFromVMIStatus(vmi *kubevirtv1.VirtualMachineInstance, networkInterfac
 		return nil
 	}
 	return ifaceStatus.IPs
-}
-
-func virtualMachineInstancePod(vmi *kubevirtv1.VirtualMachineInstance) (*corev1.Pod, error) {
-	pod, err := lookupPodBySelector(vmi.Namespace, vmiLabelSelector(vmi), vmiFieldSelector(vmi))
-	if err != nil {
-		return nil, fmt.Errorf("failed to find pod for VMI %s (%s)", vmi.Name, string(vmi.GetUID()))
-	}
-	return pod, nil
-}
-
-func lookupPodBySelector(namespace string, labelSelector, fieldSelector map[string]string) (*corev1.Pod, error) {
-	pods := &corev1.PodList{}
-	err := Client.List(
-		context.Background(),
-		pods,
-		client.InNamespace(namespace),
-		client.MatchingLabels(labelSelector),
-		client.MatchingFields(fieldSelector))
-	if err != nil {
-		return nil, err
-	}
-
-	if len(pods.Items) == 0 {
-		return nil, fmt.Errorf("failed to lookup pod with labels %v, fields %v in namespace %s", labelSelector, fieldSelector, namespace)
-	}
-
-	return &pods.Items[0], nil
-}
-
-func vmiLabelSelector(vmi *kubevirtv1.VirtualMachineInstance) map[string]string {
-	return map[string]string{kubevirtv1.CreatedByLabel: string(vmi.GetUID())}
-}
-
-func vmiFieldSelector(vmi *kubevirtv1.VirtualMachineInstance) map[string]string {
-	fieldSelectors := map[string]string{}
-	if vmi.Status.Phase == kubevirtv1.Running {
-		const podPhase = "status.phase"
-		fieldSelectors[podPhase] = string(corev1.PodRunning)
-	}
-	return fieldSelectors
-}
-
-func parsePodNetworkStatusAnnotation(podNetStatus string) ([]nadv1.NetworkStatus, error) {
-	if len(podNetStatus) == 0 {
-		return nil, fmt.Errorf("network status annotation not found")
-	}
-
-	var netStatus []nadv1.NetworkStatus
-	if err := json.Unmarshal([]byte(podNetStatus), &netStatus); err != nil {
-		return nil, err
-	}
-
-	return netStatus, nil
-}
-
-func DefaultNetworkStatus(vmi *kubevirtv1.VirtualMachineInstance) (*nadv1.NetworkStatus, error) {
-	virtLauncherPod, err := virtualMachineInstancePod(vmi)
-	if err != nil {
-		return nil, err
-	}
-
-	netStatuses, err := parsePodNetworkStatusAnnotation(virtLauncherPod.Annotations[nadv1.NetworkStatusAnnot])
-	if err != nil {
-		return nil, err
-	}
-
-	for _, netStatus := range netStatuses {
-		if netStatus.Default {
-			return &netStatus, nil
-		}
-	}
-	return nil, fmt.Errorf("primary IPs not found")
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently in the e2e persistent-ips the method of retrieving the IPs from the VM differs between primary and secondary UDN VMs. The reason for the difference is that primary UDN VMs did not support publishing the IPs via VMI.status.

Due to improvements in kubevirt/kubevirt the interface on vmi.status (https://github.com/kubevirt/kubevirt/pull/13018) the vmi interface is now published on the vmi.status - also for primary UDN VMs. 

Changing the primary UDN e2e function that retrieves the IPs to use the vmi.status allows us to simplify the e2e by unifying the function that retrieves the VMI IPs. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
This PR relies on #73 

**Release note**:
```release-note
NONE
```

