### PR TITLE
test/e2e: Run in parallel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ test-e2e: ginkgo
 	export PATH=$$(pwd)/.output/ovn-kubernetes/bin:$${PATH} && \
 	export REPORT_PATH=$$(pwd)/.output/ && \
 	cd test/e2e && \
-	$(GINKGO) -v --timeout=${E2E_TEST_TIMEOUT} --junit-report=$${REPORT_PATH}/test-e2e.junit.xml ${E2E_TEST_ARGS}
+	$(GINKGO) -p -v --timeout=${E2E_TEST_TIMEOUT} --junit-report=$${REPORT_PATH}/test-e2e.junit.xml ${E2E_TEST_ARGS}
 
 .PHONY: lint
 lint: golangci-lint ## Run golangci-lint linter & yamllint

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,6 @@ SHELL = /usr/bin/env bash -o pipefail
 .SHELLFLAGS = -ec
 
 E2E_TEST_TIMEOUT ?= "1h"
-E2E_TEST_ARGS ?= ""
 
 .PHONY: all
 all: build
@@ -73,12 +72,12 @@ test: manifests generate fmt vet envtest ## Run tests.
 
 # Utilize Kind or modify the e2e tests to load the image locally, enabling compatibility with other vendors.
 .PHONY: test-e2e  # Run the e2e tests against a Kind k8s instance that is spun up.
-test-e2e:
+test-e2e: ginkgo
 	export KUBECONFIG=${KUBECONFIG} && \
 	export PATH=$$(pwd)/.output/ovn-kubernetes/bin:$${PATH} && \
 	export REPORT_PATH=$$(pwd)/.output/ && \
 	cd test/e2e && \
-	go test -test.v --ginkgo.v --test.timeout=${E2E_TEST_TIMEOUT} ${E2E_TEST_ARGS} --ginkgo.junit-report=$${REPORT_PATH}/test-e2e.junit.xml
+	$(GINKGO) -v --timeout=${E2E_TEST_TIMEOUT} --junit-report=$${REPORT_PATH}/test-e2e.junit.xml ${E2E_TEST_ARGS}
 
 .PHONY: lint
 lint: golangci-lint ## Run golangci-lint linter & yamllint
@@ -164,12 +163,14 @@ KUSTOMIZE ?= $(LOCALBIN)/kustomize-$(KUSTOMIZE_VERSION)
 CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen-$(CONTROLLER_TOOLS_VERSION)
 ENVTEST ?= $(LOCALBIN)/setup-envtest-$(ENVTEST_VERSION)
 GOLANGCI_LINT = $(LOCALBIN)/golangci-lint-$(GOLANGCI_LINT_VERSION)
+GINKGO = $(LOCALBIN)/ginkgo-$(GINKGO_VERSION)
 
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v5.3.0
 CONTROLLER_TOOLS_VERSION ?= v0.14.0
 ENVTEST_VERSION ?= latest
 GOLANGCI_LINT_VERSION ?= v1.54.2
+GINKGO_VERSION ?= v2.22.0
 
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.
@@ -190,6 +191,10 @@ $(ENVTEST): $(LOCALBIN)
 golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.
 $(GOLANGCI_LINT): $(LOCALBIN)
 	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/cmd/golangci-lint,${GOLANGCI_LINT_VERSION})
+
+.PHONY: ginkgo
+ginkgo:
+	$(call go-install-tool,$(GINKGO),github.com/onsi/ginkgo/v2/ginkgo,${GINKGO_VERSION})
 
 .PHONY: cluster-up
 cluster-up:

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -59,7 +59,7 @@ func logCommand(args []string, topic string, failureCount int) {
 		return
 	}
 
-	fileName := fmt.Sprintf(logsDir+"/%d_%s.log", failureCount, topic)
+	fileName := fmt.Sprintf(logsDir+"/%d_%d_%s.log", GinkgoParallelProcess(), failureCount, topic)
 	file, err := os.Create(fileName)
 	if err != nil {
 		fmt.Printf("Error running command %v, err %v\n", args, err)

--- a/test/e2e/persistentips_test.go
+++ b/test/e2e/persistentips_test.go
@@ -63,7 +63,7 @@ var _ = DescribeTableSubtree("Persistent IPs", func(params testParams) {
 	JustAfterEach(func() {
 		if CurrentSpecReport().Failed() {
 			failureCount++
-			By(fmt.Sprintf("Test failed, collecting logs and artifacts, failure count %d", failureCount))
+			By(fmt.Sprintf("Test failed, collecting logs and artifacts, failure count %d, process %d", failureCount, GinkgoParallelProcess()))
 
 			logCommand([]string{"get", "pods", "-A"}, "pods", failureCount)
 			logCommand([]string{"get", "vm", "-A", "-oyaml"}, "vms", failureCount)

--- a/test/env/generate.go
+++ b/test/env/generate.go
@@ -2,10 +2,12 @@ package env
 
 import (
 	"fmt"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/utils/pointer"
 
 	nadv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
@@ -14,7 +16,8 @@ import (
 )
 
 func GenerateLayer2WithSubnetNAD(nadName, namespace, role string) *nadv1.NetworkAttachmentDefinition {
-	networkName := "l2"
+	const randCharacters = 5
+	networkName := strings.Join([]string{"l2", role, rand.String(randCharacters)}, "-")
 	return &nadv1.NetworkAttachmentDefinition{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is running the e2e tests in parallel, as tests should be independent of each other. 
The amount of threads depends on the number of CPUs available in the machine running the CI.
Running it on the PR should increase CI time, and potentially expose bugs.

e2e run example: `E2E_TEST_ARGS='--focus="should keep ips after live migration"' make test-e2e`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```

