### PR TITLE
README: Remove usage of deprecated .spec.running field

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ metadata:
     kubevirt.io/vm: vm-a
   name: vm-a
 spec:
-  running: true
+  runStrategy: Always
   template:
     metadata:
       name: vm-a


### PR DESCRIPTION
**What this PR does / why we need it**:
The .spec.running field is deprecated, therefore we should runStrategy instead.

For more info, look at:
kubevirt/kubevirt#11993

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```

