### PR TITLE
Set the GitHub runner image to Ubuntu 22.04 explicitly.

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build-linters-unit-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
 
     - uses: actions/checkout@v3
@@ -39,7 +39,7 @@ jobs:
     - name: Test
       run: ENVTEST_VERSION="release-0.17" make test
   e2e:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
 
     - uses: actions/checkout@v3

--- a/.github/workflows/publish-img.yaml
+++ b/.github/workflows/publish-img.yaml
@@ -13,7 +13,7 @@ env:
 jobs:
   push-amd64:
     name: Image push/amd64
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     permissions:
       contents: write


### PR DESCRIPTION
ubuntu-latest now uses Ubuntu 24.04, while it used to use 22.04. To unblock Github CI in the short term, we set it to ubuntu-22.04.


**What this PR does / why we need it**:
It has been observed that build actions, such as free disk space, are broken
with ubuntu-latest, which now points to Ubuntu 24.04. To resolve this,
we are switching to the ubuntu-22.04 tag, which was previously used by ubuntu-latest.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Please check error logs on PR: https://github.com/kubevirt/ipam-extensions/pull/78
please check issue: https://github.com/actions/runner-images/issues/10636

**Release note**:

```release-note
None
```

