### PR TITLE
Remove non-existent package msbuild in latest ubuntu images

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build-linters-unit-tests:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
 
     - uses: actions/checkout@v3
@@ -39,7 +39,7 @@ jobs:
     - name: Test
       run: ENVTEST_VERSION="release-0.17" make test
   e2e:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
 
     - uses: actions/checkout@v3
@@ -57,7 +57,7 @@ jobs:
           azure-cli aspnetcore-* dotnet-* ghc-* firefox \
           google-chrome-stable \
           llvm-* microsoft-edge-stable mono-* \
-          msbuild mysql-server-core-* php-* php7* \
+          mysql-server-core-* php-* php7* \
           powershell temurin-* zulu-*
 
     - name: Start cluster

--- a/.github/workflows/publish-img.yaml
+++ b/.github/workflows/publish-img.yaml
@@ -13,7 +13,7 @@ env:
 jobs:
   push-amd64:
     name: Image push/amd64
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     permissions:
       contents: write


### PR DESCRIPTION
…ntu images.


**What this PR does / why we need it**:
Build actions, including free disk space, are broken on ubuntu-latest, which now points to Ubuntu 24.04. To resolve this, we have removed the non-existent package from ubuntu-latest.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
We are making these changes to align with the updates in OVN-Kubernetes, as seen in [PR #4920](https://github.com/ovn-kubernetes/ovn-kubernetes/pull/4920).


**Release note**:

```release-note
None
```

