### PR TITLE
Add multiplatform support for ipam-controller image.

### DIFF
--- a/.github/workflows/publish-img.yaml
+++ b/.github/workflows/publish-img.yaml
@@ -9,10 +9,11 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: kubevirt/ipam-controller
   PASST_BINDING_CNI_IMAGE_NAME: kubevirt/passt-binding-cni
+  BUILD_PLATFORMS: linux/amd64,linux/arm64,linux/s390x
 
 jobs:
-  push-amd64:
-    name: Image push/amd64
+  push-image:
+    name: Image push
     runs-on: ubuntu-latest
 
     permissions:
@@ -53,6 +54,7 @@ jobs:
           push: true
           tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
           file: Dockerfile
+          platforms: ${{ env.BUILD_PLATFORMS }}
 
       - name: Push latest passt binding cni container image
         if: github.repository_owner == 'kubevirt'
@@ -73,6 +75,7 @@ jobs:
           push: true
           tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}
           file: Dockerfile
+          platforms: ${{ env.BUILD_PLATFORMS }}
 
       - name: Push stable passt binding cni container image
         if: startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
enable build process to support various architectures (e.g., amd64, arm64, and s390x) for ipam-controller.

**What this PR does / why we need it**:
Currently, the ipam-controller image is supported only on the amd64 architecture. You can find the image here: [ipam-controller image](https://github.com/kubevirt/ipam-extensions/pkgs/container/ipam-controller). With the changes from these PRs, we are now able to build and push an image that supports multiple platforms.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
None
```

