### PR TITLE
e2e, primaryUDN: Align with OVNK changes

### DIFF
--- a/test/e2e/persistentips_test.go
+++ b/test/e2e/persistentips_test.go
@@ -378,7 +378,7 @@ ethernets:
 		testenv.WithInterface(kubevirtv1.Interface{
 			Name: interfaceName,
 			Binding: &kubevirtv1.PluginBinding{
-				Name: "managedTap",
+				Name: "l2bridge",
 			},
 		}),
 		testenv.WithNetwork(kubevirtv1.Network{

--- a/test/e2e/persistentips_test.go
+++ b/test/e2e/persistentips_test.go
@@ -83,7 +83,11 @@ var _ = DescribeTableSubtree("Persistent IPs", func(params testParams) {
 
 		BeforeEach(func() {
 			td = testenv.GenerateTestData()
-			td.SetUp()
+			labels := map[string]string{}
+			if params.role == rolePrimary {
+				labels["k8s.ovn.org/primary-user-defined-network"] = ""
+			}
+			td.SetUp(labels)
 			DeferCleanup(func() {
 				td.TearDown()
 			})

--- a/test/env/env.go
+++ b/test/env/env.go
@@ -55,10 +55,10 @@ func GenerateTestData() TestData {
 	}
 }
 
-func (td *TestData) SetUp() {
+func (td *TestData) SetUp(nsLabels map[string]string) {
 	GinkgoHelper()
 	By(fmt.Sprintf("Creating namespace %s", td.Namespace))
-	Expect(Client.Create(context.Background(), &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: td.Namespace}})).To(Succeed())
+	Expect(Client.Create(context.Background(), &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: td.Namespace, Labels: nsLabels}})).To(Succeed())
 }
 
 func (td *TestData) TearDown() {


### PR DESCRIPTION
**What this PR does / why we need it**:
1. Following the [change](https://github.com/ovn-kubernetes/ovn-kubernetes/pull/4854) on ovn-kubevernets, this PR aligns the binding name to `l2bridge`.
2. Following the [change](https://github.com/ovn-kubernetes/ovn-kubernetes/pull/4912) on ovn-kubevernets, this PR aligns the namespace to have the primary UDN label.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
3. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

