### PR TITLE
nad: Skip NADs with empty config

### DIFF
--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -21,6 +21,9 @@ type RelevantConfig struct {
 
 func NewConfig(nadSpec string) (*RelevantConfig, error) {
 	nadConfig := &RelevantConfig{}
+	if nadSpec == "" {
+		return nadConfig, nil
+	}
 	if err := json.Unmarshal([]byte(nadSpec), nadConfig); err != nil {
 		return nil, fmt.Errorf("failed to extract CNI configuration from NAD: %w", err)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Until now, a NAD with empty config, was considered invalid,
causing an error / rejecting it on the webhook.
Istio creates such NADs, so we can't consider them as fatal,
once we list all the NADs in a namespace.
Otherwise the webhook will block VM creation [1] in case it uses
such NAD.

Therefore just ignore those.


```
[1] virtualmachine-controller    Error creating pod: admission webhook "ipam-claims.k8s.cni.cncf.io" denied the request: failed to extract CNI configuration from NAD: unexpected end of JSON input
```

Example of resource that create such NAD:
```
apiVersion: maistra.io/v1
kind: ServiceMeshMemberRoll
metadata:
  name: default
  namespace: istio-system
spec:
  members:
  - non-udn-ns
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

