### PR TITLE
Add multi-arch support for passt binding.

### DIFF
--- a/.github/workflows/publish-img.yaml
+++ b/.github/workflows/publish-img.yaml
@@ -64,6 +64,7 @@ jobs:
           push: true
           tags: ${{ env.REGISTRY }}/${{ env.PASST_BINDING_CNI_IMAGE_NAME }}:latest
           file: passt/Dockerfile
+          platforms: ${{ env.BUILD_PLATFORMS }}
           build-args: |
             KUBEVIRT_VERSION=${{ env.KUBEVIRT_VERSION }}
 
@@ -85,6 +86,7 @@ jobs:
           push: true
           tags: ${{ env.REGISTRY }}/${{ env.PASST_BINDING_CNI_IMAGE_NAME }}:${{ github.ref_name }}
           file: passt/Dockerfile
+          platforms: ${{ env.BUILD_PLATFORMS }}
           build-args: |
             KUBEVIRT_VERSION=${{ env.KUBEVIRT_VERSION }}
 


### PR DESCRIPTION
enable build process to support various architectures (e.g., amd64, arm64, and s390x) for passt binding.

**What this PR does / why we need it**:
This PR enables multi-architecture support for the passthrough binding CNI(https://github.com/kubevirt/ipam-extensions/pkgs/container/passt-binding-cni) . Previously, we added multi-arch support for all CNIs used in CNAO . However, passthrough binding currently lacks multi-arch support, and since CNAO still uses it when deploying the IPAM controller CNI, this causes failures. To prevent these failures, we are implementing this temporary workaround till we remove passt binding.

To be more precise, this process will build a multi-architecture image, but the binary inside will still be for amd64.
please note that currently, KubeVirt is only releasing the passt-binding binary for amd64 (see the release here: [KubeVirt passt-binding v1.5.0](https://github.com/kubevirt/kubevirt/releases/download/v1.5.0/kubevirt-passt-binding)).
https://github.com/kubevirt/kubevirt/releases/tag/v1.5.0

we need to add support for arm and s390x so that we can build image with proper binary here(https://github.com/ashokpariya0/ipam-extensions/blob/a1ee313f0ee9653190bf6dc1f850bdfc7cb209b5/passt/Dockerfile#L8)

For now, this change will allow us to successfully deploy the IPAM controller with passt binding on other arch like arm, s390x.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
None
```

