### PR TITLE
Add build-platforms env variable for multi-arch build.

### DIFF
--- a/.github/workflows/publish-img.yaml
+++ b/.github/workflows/publish-img.yaml
@@ -8,6 +8,7 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: kubevirt/ipam-controller
+  BUILD_PLATFORMS: linux/amd64,linux/arm64,linux/s390x
 
 jobs:
   push-image:


### PR DESCRIPTION

**What this PR does / why we need it**:

last merged PR ([#94](https://github.com/kubevirt/ipam-extensions/pull/94))  removed multi-arch support for the ipam-controller ([v0.2.3](https://github.com/kubevirt/ipam-extensions/pkgs/container/ipam-controller/381539608?tag=v0.2.3)).

We are re-adding the BUILD_PLATFORM environment variable to enable multi-architecture builds.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```release-note
None
```

