### PR TITLE
Set container's TerminationMessagePolicy to FallbackToLogsOnError

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -88,6 +88,7 @@ spec:
           requests:
             cpu: 10m
             memory: 128Mi
+        terminationMessagePolicy: FallbackToLogsOnError
       priorityClassName: system-cluster-critical
       serviceAccountName: manager
       terminationGracePeriodSeconds: 10

--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -252,6 +252,7 @@ spec:
           capabilities:
             drop:
             - ALL
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: cert


### PR DESCRIPTION
**What this PR does / why we need it**:
To comply with best practices, all the containers in all the pods, must set the TerminationMessagePolicy field to FallbackToLogsOnError [0]

[0]
https://github.com/redhat-best-practices-for-k8s/certsuite/blob/main/CATALOG.md#observability-termination-policy

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
checked manually:
```
[root@hades04 ipam-extensions]# kubectl get pod -nkubevirt-ipam-controller-system -ojson | jq .items[0].spec.containers[0].terminationMessagePolicy
"FallbackToLogsOnError"

```
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

