### PR TITLE
Add Network policies

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -18,6 +18,7 @@ resources:
 - ../manager
 - ../webhook
 - ../certmanager
+- ../networkpolicy
 
 patches:
 - path: manager_webhook_patch.yaml

--- a/config/networkpolicy/allow-egress-dns.yaml
+++ b/config/networkpolicy/allow-egress-dns.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-egress-to-dns
+spec:
+  podSelector:
+    matchLabels:
+      app: ipam-virt-workloads
+  policyTypes:
+  - Egress
+  egress:
+    - to:
+      - namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: kube-system
+        podSelector:
+          matchLabels:
+            k8s-app: kube-dns
+      ports:
+        - protocol: TCP
+          port: dns-tcp
+        - protocol: UDP
+          port: dns

--- a/config/networkpolicy/allow-egress-kube-apiserver.yaml
+++ b/config/networkpolicy/allow-egress-kube-apiserver.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-egress-to-api-server
+spec:
+  podSelector:
+    matchLabels:
+      app: ipam-virt-workloads
+  policyTypes:
+  - Egress
+  egress:
+  - ports:
+    - protocol: TCP
+      port: 6443

--- a/config/networkpolicy/allow-ingress-to-service.yaml
+++ b/config/networkpolicy/allow-ingress-to-service.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-ingress-to-ipam-ext-webhook
+spec:
+  podSelector:
+    matchLabels:
+      app: ipam-virt-workloads
+  policyTypes:
+    - Ingress
+  ingress:
+  - ports:
+    - protocol: TCP
+      port: 9443

--- a/config/networkpolicy/kustomization.yaml
+++ b/config/networkpolicy/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- allow-egress-dns.yaml
+- allow-egress-kube-apiserver.yaml
+- allow-ingress-to-service.yaml

--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -308,6 +308,70 @@ metadata:
 spec:
   selfSigned: {}
 ---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    app: ipam-virt-workloads
+  name: kubevirt-ipam-controller-allow-egress-to-api-server
+  namespace: kubevirt-ipam-controller-system
+spec:
+  egress:
+  - ports:
+    - port: 6443
+      protocol: TCP
+  podSelector:
+    matchLabels:
+      app: ipam-virt-workloads
+  policyTypes:
+  - Egress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    app: ipam-virt-workloads
+  name: kubevirt-ipam-controller-allow-egress-to-dns
+  namespace: kubevirt-ipam-controller-system
+spec:
+  egress:
+  - ports:
+    - port: dns-tcp
+      protocol: TCP
+    - port: dns
+      protocol: UDP
+    to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: kube-system
+      podSelector:
+        matchLabels:
+          app: ipam-virt-workloads
+          k8s-app: kube-dns
+  podSelector:
+    matchLabels:
+      app: ipam-virt-workloads
+  policyTypes:
+  - Egress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    app: ipam-virt-workloads
+  name: kubevirt-ipam-controller-allow-ingress-to-ipam-ext-webhook
+  namespace: kubevirt-ipam-controller-system
+spec:
+  ingress:
+  - ports:
+    - port: 9443
+      protocol: TCP
+  podSelector:
+    matchLabels:
+      app: ipam-virt-workloads
+  policyTypes:
+  - Ingress
+---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:

--- a/hack/cluster.sh
+++ b/hack/cluster.sh
@@ -73,6 +73,10 @@ function sync() {
     # Generate the manifest with the "sha256" to force kubernetes to reload the image
     sha=$(skopeo inspect --tls-verify=false docker://$img:$tag |jq -r .Digest)
     IMG=$img@$sha make deploy
+
+    # Ensure the project network-polices are valid by installing an additional deny-all network-policy affecting the project namespace
+    ./hack/install-deny-all-net-pol.sh
+
     ${KUBECTL} rollout status -w -n kubevirt-ipam-controller-system deployment kubevirt-ipam-controller-manager --timeout 2m
 }
 

--- a/hack/install-deny-all-net-pol.sh
+++ b/hack/install-deny-all-net-pol.sh
@@ -1,0 +1,37 @@
+#!/bin/bash -ex
+#
+# Copyright 2025 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# This script install deny-all NetworkPolicy that affects kubevirt-ipam-controller namespace.
+
+readonly ns="$(${KUBECTL} get pod -l app=ipam-virt-workloads -A -o=custom-columns=NS:.metadata.namespace --no-headers | head -1)"
+[[ -z "${ns}" ]] && echo "FATAL: kubevirt-ipam-controller pods not found. Make sure kubevirt-ipam-controller is installed" && exit 1
+
+readonly np_name="deny-all"
+${KUBECTL} -n "${ns}" get networkpolicy "${np_name}" &> /dev/null ||
+  cat <<EOF | ${KUBECTL} -n "${ns}" apply -f -
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: ${np_name}
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress: []
+  egress: []
+EOF


### PR DESCRIPTION
**What this PR does / why we need it**:
In a scenario where a cluster networking has been hardened and futures
a default deny-all network policy that affects kubevirt-ipam-controller namespace,
it will not be able to operate properly.

This PR introduce network-policies for the project allowing kubevirt-ipam-controller to operate,
complying with restrictions in form of deny all network-policy.

**Special notes for your reviewer**:
In order to have coverage for the introduced network-policies, and additional deny-all network-policies is installed as part of the cluster-sync flow.
Having a deny-all network-policy installed, allow the introduced network-policies to be tested in a development and test environments, locally and CI.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
config: Introduce network-policies enable kubevirt-ipam-controller operate in restricted env
```
