### PR TITLE
claims: Format key to domain name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ check-vendoring: vendor fmt vet
 
 .PHONY: test
 test: manifests generate fmt vet envtest ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test $$(go list ./... | grep -v /e2e) -coverprofile cover.out -v -ginkgo.v
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test $$(go list ./... | grep -v /e2e) -coverprofile cover.out -v -ginkgo.v $(TEST_ARGS)
 
 # Utilize Kind or modify the e2e tests to load the image locally, enabling compatibility with other vendors.
 .PHONY: test-e2e  # Run the e2e tests against a Kind k8s instance that is spun up.

--- a/pkg/vminetworkscontroller/vmi_controller_test.go
+++ b/pkg/vminetworkscontroller/vmi_controller_test.go
@@ -151,7 +151,7 @@ var _ = Describe("VMI IPAM controller", Serial, func() {
 			expectedIPAMClaims: []ipamclaimsapi.IPAMClaim{
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:       fmt.Sprintf("%s.%s", vmName, "randomnet"),
+						Name:       claims.ComposeKey(vmName, "random_net"),
 						Namespace:  namespace,
 						Finalizers: []string{claims.KubevirtVMFinalizer},
 						Labels:     claims.OwnedByVMLabel(vmName),
@@ -167,7 +167,7 @@ var _ = Describe("VMI IPAM controller", Serial, func() {
 				},
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:       fmt.Sprintf("%s.%s", vmName, "podnet"),
+						Name:       claims.ComposeKey(vmName, "podnet"),
 						Namespace:  namespace,
 						Finalizers: []string{claims.KubevirtVMFinalizer},
 						Labels:     claims.OwnedByVMLabel(vmName),
@@ -225,7 +225,7 @@ var _ = Describe("VMI IPAM controller", Serial, func() {
 			expectedResponse: reconcile.Result{},
 			existingIPAMClaim: &ipamclaimsapi.IPAMClaim{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:       fmt.Sprintf("%s.%s", vmName, "randomnet"),
+					Name:       claims.ComposeKey(vmName, "random_net"),
 					Namespace:  namespace,
 					Finalizers: []string{claims.KubevirtVMFinalizer},
 					Labels:     claims.OwnedByVMLabel(vmName),
@@ -235,7 +235,7 @@ var _ = Describe("VMI IPAM controller", Serial, func() {
 			expectedIPAMClaims: []ipamclaimsapi.IPAMClaim{
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "vm1.randomnet",
+						Name:      claims.ComposeKey(vmName, "random_net"),
 						Namespace: "ns1",
 						Labels:    claims.OwnedByVMLabel(vmName),
 					},
@@ -248,7 +248,7 @@ var _ = Describe("VMI IPAM controller", Serial, func() {
 			expectedResponse: reconcile.Result{},
 			existingIPAMClaim: &ipamclaimsapi.IPAMClaim{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:       fmt.Sprintf("%s.%s", vmName, "randomnet"),
+					Name:       claims.ComposeKey(vmName, "random_net"),
 					Namespace:  namespace,
 					Finalizers: []string{claims.KubevirtVMFinalizer},
 					Labels:     claims.OwnedByVMLabel(vmName),
@@ -258,7 +258,7 @@ var _ = Describe("VMI IPAM controller", Serial, func() {
 			expectedIPAMClaims: []ipamclaimsapi.IPAMClaim{
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:       "vm1.randomnet",
+						Name:       claims.ComposeKey(vmName, "random_net"),
 						Namespace:  "ns1",
 						Finalizers: []string{claims.KubevirtVMFinalizer},
 						Labels:     claims.OwnedByVMLabel(vmName),
@@ -272,7 +272,7 @@ var _ = Describe("VMI IPAM controller", Serial, func() {
 			expectedResponse: reconcile.Result{},
 			existingIPAMClaim: &ipamclaimsapi.IPAMClaim{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:       fmt.Sprintf("%s.%s", vmName, "randomnet"),
+					Name:       claims.ComposeKey(vmName, "random_net"),
 					Namespace:  namespace,
 					Finalizers: []string{claims.KubevirtVMFinalizer},
 					Labels:     claims.OwnedByVMLabel(vmName),
@@ -282,7 +282,7 @@ var _ = Describe("VMI IPAM controller", Serial, func() {
 			expectedIPAMClaims: []ipamclaimsapi.IPAMClaim{
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "vm1.randomnet",
+						Name:      claims.ComposeKey(vmName, "random_net"),
 						Namespace: "ns1",
 						Labels:    claims.OwnedByVMLabel(vmName),
 					},
@@ -298,7 +298,7 @@ var _ = Describe("VMI IPAM controller", Serial, func() {
 			expectedResponse: reconcile.Result{},
 			existingIPAMClaim: &ipamclaimsapi.IPAMClaim{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:       fmt.Sprintf("%s.%s", vmName, "randomnet"),
+					Name:       claims.ComposeKey(vmName, "random_net"),
 					Namespace:  namespace,
 					Finalizers: []string{claims.KubevirtVMFinalizer},
 					Labels:     claims.OwnedByVMLabel(vmName),
@@ -315,7 +315,7 @@ var _ = Describe("VMI IPAM controller", Serial, func() {
 			expectedIPAMClaims: []ipamclaimsapi.IPAMClaim{
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:       "vm1.randomnet",
+						Name:       claims.ComposeKey(vmName, "random_net"),
 						Namespace:  "ns1",
 						Finalizers: []string{claims.KubevirtVMFinalizer},
 						Labels:     claims.OwnedByVMLabel(vmName),
@@ -336,7 +336,7 @@ var _ = Describe("VMI IPAM controller", Serial, func() {
 			expectedResponse: reconcile.Result{},
 			existingIPAMClaim: &ipamclaimsapi.IPAMClaim{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:       fmt.Sprintf("%s.%s", vmName, "randomnet"),
+					Name:       claims.ComposeKey(vmName, "random_net"),
 					Namespace:  namespace,
 					Finalizers: []string{claims.KubevirtVMFinalizer},
 					Labels:     claims.OwnedByVMLabel(vmName),
@@ -346,7 +346,7 @@ var _ = Describe("VMI IPAM controller", Serial, func() {
 			expectedIPAMClaims: []ipamclaimsapi.IPAMClaim{
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "vm1.randomnet",
+						Name:      claims.ComposeKey(vmName, "random_net"),
 						Namespace: "ns1",
 						Labels:    claims.OwnedByVMLabel(vmName),
 					},
@@ -362,12 +362,13 @@ var _ = Describe("VMI IPAM controller", Serial, func() {
 			},
 			existingIPAMClaim: &ipamclaimsapi.IPAMClaim{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      fmt.Sprintf("%s.%s", vmName, "randomnet"),
+					Name:      claims.ComposeKey(vmName, "random_net"),
 					Namespace: namespace,
 				},
 				Spec: ipamclaimsapi.IPAMClaimSpec{Network: "doesitmatter?"},
 			},
-			expectedError: fmt.Errorf("failed since it found an existing IPAMClaim for \"vm1.randomnet\""),
+			expectedError: fmt.Errorf(`failed since it found an existing IPAMClaim for "%s"`,
+				claims.ComposeKey(vmName, "random_net")),
 		}),
 		Entry("found an existing IPAMClaim for the same VM", testConfig{
 			inputVM:  decorateVMWithUID(dummyUID, dummyVM(dummyVMISpec(nadName))),
@@ -377,7 +378,7 @@ var _ = Describe("VMI IPAM controller", Serial, func() {
 			},
 			existingIPAMClaim: &ipamclaimsapi.IPAMClaim{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      fmt.Sprintf("%s.%s", vmName, "randomnet"),
+					Name:      claims.ComposeKey(vmName, "random_net"),
 					Namespace: namespace,
 					OwnerReferences: []metav1.OwnerReference{
 						{
@@ -396,7 +397,7 @@ var _ = Describe("VMI IPAM controller", Serial, func() {
 			expectedIPAMClaims: []ipamclaimsapi.IPAMClaim{
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "vm1.randomnet",
+						Name:      claims.ComposeKey(vmName, "random_net"),
 						Namespace: "ns1",
 						Labels:    claims.OwnedByVMLabel(vmName),
 						OwnerReferences: []metav1.OwnerReference{
@@ -421,7 +422,7 @@ var _ = Describe("VMI IPAM controller", Serial, func() {
 			},
 			existingIPAMClaim: &ipamclaimsapi.IPAMClaim{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      fmt.Sprintf("%s.%s", vmName, "randomnet"),
+					Name:      claims.ComposeKey(vmName, "random_net"),
 					Namespace: namespace,
 					OwnerReferences: []metav1.OwnerReference{
 						{
@@ -436,7 +437,8 @@ var _ = Describe("VMI IPAM controller", Serial, func() {
 				},
 				Spec: ipamclaimsapi.IPAMClaimSpec{Network: "doesitmatter?"},
 			},
-			expectedError: fmt.Errorf("failed since it found an existing IPAMClaim for \"vm1.randomnet\""),
+			expectedError: fmt.Errorf(`failed since it found an existing IPAMClaim for "%s"`,
+				claims.ComposeKey(vmName, "random_net")),
 		}),
 		Entry("a lonesome VMI (with no corresponding VM) is a valid migration use-case", testConfig{
 			inputVMI: dummyVMI(dummyVMISpec(nadName)),
@@ -447,7 +449,7 @@ var _ = Describe("VMI IPAM controller", Serial, func() {
 			expectedIPAMClaims: []ipamclaimsapi.IPAMClaim{
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:       "vm1.randomnet",
+						Name:       claims.ComposeKey(vmName, "random_net"),
 						Namespace:  "ns1",
 						Labels:     claims.OwnedByVMLabel(vmName),
 						Finalizers: []string{claims.KubevirtVMFinalizer},
@@ -506,7 +508,7 @@ func dummyVMISpec(nadName string) virtv1.VirtualMachineInstanceSpec {
 				NetworkSource: virtv1.NetworkSource{Pod: &virtv1.PodNetwork{}},
 			},
 			{
-				Name: "randomnet",
+				Name: "random_net",
 				NetworkSource: virtv1.NetworkSource{
 					Multus: &virtv1.MultusNetwork{
 						NetworkName: nadName,

--- a/pkg/vmnetworkscontroller/vm_controller_test.go
+++ b/pkg/vmnetworkscontroller/vm_controller_test.go
@@ -2,7 +2,6 @@ package vmnetworkscontroller_test
 
 import (
 	"context"
-	"fmt"
 	"testing"
 	"time"
 
@@ -229,7 +228,7 @@ func dummyIPAMClaimWithFinalizer(namespace, vmName string) *ipamclaimsapi.IPAMCl
 func dummyIPAMClaimmWithoutFinalizer(namespace, vmName string) *ipamclaimsapi.IPAMClaim {
 	return &ipamclaimsapi.IPAMClaim{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("%s.%s", vmName, "randomnet"),
+			Name:      claims.ComposeKey(vmName, "randomnet"),
 			Namespace: namespace,
 			Labels:    claims.OwnedByVMLabel(vmName),
 			OwnerReferences: []metav1.OwnerReference{{

--- a/test/e2e/persistentips_test.go
+++ b/test/e2e/persistentips_test.go
@@ -42,8 +42,8 @@ import (
 )
 
 const (
-	secondaryLogicalNetworkInterfaceName = "multus"
-	primaryLogicalNetworkInterfaceName   = "pod"
+	secondaryLogicalNetworkInterfaceName = "multus_iface"
+	primaryLogicalNetworkInterfaceName   = "pod_iface"
 	nadName                              = "l2-net-attach-def"
 )
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Format new ipamclaims keys to follow kubernetes CRD name restrictions

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #https://issues.redhat.com/browse/CNV-62286

**Special notes for your reviewer**:
There is no problems from upgrades since already created ipamclaims have a proper name that do not need formatting.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
claims: Format key to domain name
```

