### PR TITLE
feat: use branch name for image tagging while keeping :latest for backward compatibility

### DIFF
--- a/.github/workflows/publish-img.yaml
+++ b/.github/workflows/publish-img.yaml
@@ -29,6 +29,20 @@ jobs:
         run: |
           echo "git_commit_hash=$(git describe --no-match  --always --abbrev=8 --dirty)" >> $GITHUB_ENV
 
+      - name: Extract branch name
+        shell: bash
+        run: |
+          # Extract branch name and sanitize it for Docker tag compatibility
+          if [[ "${{ github.ref }}" == "refs/heads/"* ]]; then
+            BRANCH_NAME="${{ github.ref#refs/heads/ }}"
+            # Replace invalid characters with dashes and convert to lowercase
+            SANITIZED_BRANCH=$(echo "$BRANCH_NAME" | sed 's/[^a-zA-Z0-9._-]/-/g' | tr '[:upper:]' '[:lower:]')
+            echo "branch_tag=${SANITIZED_BRANCH}" >> $GITHUB_ENV
+            echo "is_branch_push=true" >> $GITHUB_ENV
+          else
+            echo "is_branch_push=false" >> $GITHUB_ENV
+          fi
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3.0.0
 
@@ -40,13 +54,15 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Push latest container image
-        if: github.repository_owner == 'kubevirt'
+      - name: Push branch-based and latest container images
+        if: github.repository_owner == 'kubevirt' && env.is_branch_push == 'true'
         uses: docker/build-push-action@v5.3.0
         with:
           context: .
           push: true
-          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.branch_tag }}
           file: Dockerfile
           platforms: ${{ env.BUILD_PLATFORMS }}
 
@@ -59,6 +75,10 @@ jobs:
           tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}
           file: Dockerfile
           platforms: ${{ env.BUILD_PLATFORMS }}
+
+      - name: Template branch manifests
+        if: github.repository_owner == 'kubevirt' && env.is_branch_push == 'true'
+        run: IMG=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.branch_tag }} make build-installer
 
       - name: Template release manifests
         if: startsWith(github.ref, 'refs/tags/')

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 
 # Image URL to use all building/pushing image targets
-IMG ?= kubevirt-ipam-controller:latest
+# Default to registry path for consistency with CI/CD
+IMG ?= ghcr.io/kubevirt/ipam-controller:latest
 export KUBECONFIG ?= $(shell pwd)/.output/kubeconfig
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.32.0


### PR DESCRIPTION
**What this PR does / why we need it**:
- Update GitHub Actions workflow to publish images with both branch-based tags and :latest
- Add branch name extraction and sanitization for Docker tag compatibility
- Template manifests using branch-based tags for branch pushes
- Keep :latest tagging for backward compatibility with existing manifests
- Update install manifest to reflect current configuration

This enables better image tracking per branch while maintaining compatibility with existing deployments using :latest tags.


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Push to branch name when merged PRs.
```

