### PR TITLE
[releas-0.2.1] feat: use branch name for image tagging with improved workflow logic

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -26,10 +26,20 @@ jobs:
         version: v1.57.2
         args: --timeout 3m --verbose cmd/... pkg/...
 
-    - name: Ensure latest install manifest
+    - name: Sanitize branch name for container image tag
+      shell: bash
+      run: |
+        BRANCH_NAME="${{ github.ref_name }}"
+        if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+          BRANCH_NAME="${{ github.base_ref }}"
+        fi
+        SANITIZED_BRANCH=$(./hack/sanitize-branch.sh "${BRANCH_NAME}")
+        echo "image_tag=${SANITIZED_BRANCH}" >> $GITHUB_ENV
+
+    - name: Ensure branch contains manifests with correct image tag
       run: |
         echo "" > dist/install.yaml
-        IMG=ghcr.io/kubevirt/ipam-controller:latest make build-installer
+        IMG=ghcr.io/kubevirt/ipam-controller:${{ env.image_tag }} make build-installer
         if [[ -n "$(git status --porcelain)" ]]; then
           echo "Please run 'make build-installer' and commit those changes"
           git status --porcelain

--- a/.github/workflows/publish-img.yaml
+++ b/.github/workflows/publish-img.yaml
@@ -30,11 +30,19 @@ jobs:
         run: |
           echo "git_commit_hash=$(git describe --no-match  --always --abbrev=8 --dirty)" >> $GITHUB_ENV
 
+      - name: Extract branch name
+        shell: bash
+        run: |
+          # Extract branch name and sanitize it for Docker tag compatibility
+          if [[ "${{ github.ref_type }}" == "branch" ]]; then
+            SANITIZED_BRANCH=$(./hack/sanitize-branch.sh "${{ github.ref_name }}")
+            echo "branch_tag=${SANITIZED_BRANCH}" >> $GITHUB_ENV
+          fi
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3.0.0
 
       - name: Login to Container Registry
-        if: github.repository_owner == 'kubevirt'
         uses: docker/login-action@v3.0.0
         with:
           registry: ${{ env.REGISTRY }}
@@ -46,8 +54,18 @@ jobs:
           KUBEVIRT_VERSION=$(curl -sSL https://storage.googleapis.com/kubevirt-prow/release/kubevirt/kubevirt/stable.txt)
           echo "KUBEVIRT_VERSION=${KUBEVIRT_VERSION}" >> $GITHUB_ENV
 
+      - name: Push branch-based container images
+        if: github.ref_type == 'branch'
+        uses: docker/build-push-action@v5.3.0
+        with:
+          context: .
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.branch_tag }}
+          file: Dockerfile
+          platforms: ${{ env.BUILD_PLATFORMS }}
+
       - name: Push latest container image
-        if: github.repository_owner == 'kubevirt'
+        if: github.ref_type == 'branch' && github.ref_name == 'main'
         uses: docker/build-push-action@v5.3.0
         with:
           context: .
@@ -68,7 +86,7 @@ jobs:
             KUBEVIRT_VERSION=${{ env.KUBEVIRT_VERSION }}
 
       - name: Push stable container image
-        if: startsWith(github.ref, 'refs/tags/')
+        if: github.ref_type == 'tag'
         uses: docker/build-push-action@v5.3.0
         with:
           context: .
@@ -94,7 +112,7 @@ jobs:
 
       - name: Release the kraken
         uses: softprops/action-gh-release@v1
-        if: startsWith(github.ref, 'refs/tags/')
+        if: github.ref_type == 'tag'
         with:
           generate_release_notes: true
           files: |

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 
-# Image URL to use all building/pushing image targets
-IMG ?= kubevirt-ipam-controller:latest
+# Default to registry path for consistency with CI/CD
+IMG ?= ghcr.io/kubevirt/ipam-controller:$(shell ./hack/sanitize-branch.sh $(shell git rev-parse --abbrev-ref HEAD))
 PASST_IMG ?= kubevirt/passt-binding-cni:latest
 
 export KUBECONFIG ?= $(shell pwd)/.output/kubeconfig

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: ghcr.io/kubevirt/ipam-controller
-  newTag: latest
+  newTag: release-0.2.1

--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -225,7 +225,7 @@ spec:
         - --leader-elect
         command:
         - /manager
-        image: ghcr.io/kubevirt/ipam-controller:latest
+        image: ghcr.io/kubevirt/ipam-controller:release-0.2.1
         livenessProbe:
           httpGet:
             path: /healthz

--- a/hack/sanitize-branch.sh
+++ b/hack/sanitize-branch.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# sanitize-branch.sh
+# Sanitizes a branch name to be used as a Docker container tag
+# Usage: ./hack/sanitize-branch.sh "branch-name"
+# or: echo "branch-name" | ./hack/sanitize-branch.sh
+
+set -euo pipefail
+
+# Get input from argument or stdin
+if [ $# -eq 1 ]; then
+    BRANCH_NAME="$1"
+elif [ $# -eq 0 ]; then
+    # Read from stdin if no arguments provided
+    read -r BRANCH_NAME
+else
+    echo "Usage: $0 [branch-name]" >&2
+    echo "  or: echo 'branch-name' | $0" >&2
+    exit 1
+fi
+
+# Sanitize branch name for Docker tag compatibility:
+# 1. Replace any character that's not alphanumeric, dot, underscore, or hyphen with hyphen
+# 2. Convert to lowercase
+# 3. Remove leading/trailing hyphens and dots (Docker tags can't start/end with these)
+# 4. Replace consecutive hyphens with single hyphen
+# 5. Truncate to 128 characters max (Docker tag limit)
+
+SANITIZED=$(echo "$BRANCH_NAME" | \
+    sed 's/[^a-zA-Z0-9._-]/-/g' | \
+    tr '[:upper:]' '[:lower:]' | \
+    sed 's/^[-.]*//' | \
+    sed 's/[-]*$//' | \
+    sed 's/--*/-/g' | \
+    cut -c1-128)
+
+# If the result is empty or starts with invalid characters, default to "main"
+if [[ -z "$SANITIZED" ]] || [[ "$SANITIZED" =~ ^[.-] ]]; then
+    SANITIZED="main"
+fi
+
+echo "$SANITIZED" 


### PR DESCRIPTION
**What this PR does / why we need it**:
- Add branch-based image tagging using sanitized branch names
- Create reusable hack/sanitize-branch.sh script for branch name sanitization
- Use github.ref_type and github.ref_name for cleaner conditional logic
- Split image pushing into separate steps for better control:
  - Push branch-based tags for all branch pushes
  - Push :latest tag only for main branch pushes
  - Keep stable tag pushing for release tags
- Update both publish-img.yaml and checks.yaml workflows to use branch-based tagging
- Maintain backward compatibility with existing :latest references
- Update Makefile to use full registry path for consistency
- Generate branch-specific manifests for non-release pushes

The sanitization script handles Docker tag requirements:
- Converts to lowercase
- Replaces invalid characters with hyphens
- Removes leading/trailing hyphens and dots
- Handles consecutive hyphens
- Truncates to 128 character limit
- Provides fallback to 'main' for invalid results

Both workflows now consistently use branch-based tagging for better tracking while maintaining compatibility with existing deployments that rely on :latest tags.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

