### PR TITLE
network-policy: Use digit ports

### DIFF
--- a/config/networkpolicy/allow-ingress-to-webhook.yaml
+++ b/config/networkpolicy/allow-ingress-to-webhook.yaml
@@ -12,4 +12,4 @@ spec:
   ingress:
   - ports:
     - protocol: TCP
-      port: webhook-server
+      port: 9443

--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -318,7 +318,7 @@ metadata:
 spec:
   ingress:
   - ports:
-    - port: webhook-server
+    - port: 9443
       protocol: TCP
   podSelector:
     matchLabels:

--- a/hack/install-deny-all-net-pol.sh
+++ b/hack/install-deny-all-net-pol.sh
@@ -70,7 +70,7 @@ spec:
             k8s-app: kube-dns
       ports:
         - protocol: TCP
-          port: dns-tcp
+          port: 53
         - protocol: UDP
-          port: dns
+          port: 53
 EOF


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Some CNIs does not support named ports (e.g.: ovn-kubernetes), hence use digit ports

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

