### PR TITLE
test: Fix broken CI lane

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,9 +78,9 @@ test: manifests generate fmt vet envtest ## Run tests.
 
 # Utilize Kind or modify the e2e tests to load the image locally, enabling compatibility with other vendors.
 .PHONY: test-e2e  # Run the e2e tests against a Kind k8s instance that is spun up.
-test-e2e: ginkgo
+test-e2e: ginkgo virtctl
 	export KUBECONFIG=${KUBECONFIG} && \
-	export PATH=$$(pwd)/.output/ovn-kubernetes/bin:$${PATH} && \
+	export PATH=$$(pwd)/bin:$$(pwd)/.output/ovn-kubernetes/bin:$${PATH} && \
 	export REPORT_PATH=$$(pwd)/.output/ && \
 	cd test/e2e && \
 	$(GINKGO) -p -v --timeout=${E2E_TEST_TIMEOUT} --junit-report=$${REPORT_PATH}/test-e2e.junit.xml ${E2E_TEST_ARGS}
@@ -167,6 +167,7 @@ CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen-$(CONTROLLER_TOOLS_VERSION)
 ENVTEST ?= $(LOCALBIN)/setup-envtest-$(ENVTEST_VERSION)
 GOLANGCI_LINT = $(LOCALBIN)/golangci-lint-$(GOLANGCI_LINT_VERSION)
 GINKGO = $(LOCALBIN)/ginkgo-$(GINKGO_VERSION)
+VIRTCTL = $(LOCALBIN)/virtctl
 
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v5.3.0
@@ -198,6 +199,14 @@ $(GOLANGCI_LINT): $(LOCALBIN)
 .PHONY: ginkgo
 ginkgo:
 	$(call go-install-tool,$(GINKGO),github.com/onsi/ginkgo/v2/ginkgo,${GINKGO_VERSION})
+
+.PHONY: virtctl
+virtctl: $(VIRTCTL) ## Download virtctl locally if necessary.
+$(VIRTCTL): $(LOCALBIN)
+	@echo "Installing virtctl..."
+	@export VERSION=$$(curl -s https://storage.googleapis.com/kubevirt-prow/release/kubevirt/kubevirt/stable.txt) && \
+	wget -q https://github.com/kubevirt/kubevirt/releases/download/$${VERSION}/virtctl-$${VERSION}-linux-amd64 -O $(VIRTCTL) && \
+	chmod +x $(VIRTCTL)
 
 .PHONY: cluster-up
 cluster-up:

--- a/test/e2e/persistentips_test.go
+++ b/test/e2e/persistentips_test.go
@@ -156,7 +156,7 @@ var _ = DescribeTableSubtree("Persistent IPs", func(params testParams) {
 				BeforeEach(func() {
 					By("Invoking virtctl stop")
 					output, err := exec.Command("virtctl", "stop", "-n", td.Namespace, vmi.Name).CombinedOutput()
-					Expect(err).NotTo(HaveOccurred(), output)
+					Expect(err).NotTo(HaveOccurred(), string(output))
 
 					By("Ensuring VM is not running")
 					Eventually(testenv.ThisVMI(vmi), 360*time.Second, 1*time.Second).Should(
@@ -198,7 +198,7 @@ var _ = DescribeTableSubtree("Persistent IPs", func(params testParams) {
 
 				By("Re-starting the VM")
 				output, err := exec.Command("virtctl", "restart", "-n", td.Namespace, vmi.Name).CombinedOutput()
-				Expect(err).NotTo(HaveOccurred(), output)
+				Expect(err).NotTo(HaveOccurred(), string(output))
 
 				By("Wait for a new VMI to be re-started")
 				Eventually(testenv.ThisVMI(vmi)).


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is fixing several issuw causing the e2e lane to fail:
- conversion issue that caused e2e tests to panic.
- virtctl not installed

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

