### PR TITLE
vendor: Bump network-attachment-definition-client to v1.7.7

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.23.4
 require (
 	github.com/go-logr/logr v1.4.2
 	github.com/k8snetworkplumbingwg/ipamclaims v0.5.0-alpha
-	github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.7.5
+	github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.7.7
 	github.com/onsi/ginkgo/v2 v2.22.2
 	github.com/onsi/gomega v1.36.2
 	gomodules.xyz/jsonpatch/v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -118,8 +118,8 @@ github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnr
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/k8snetworkplumbingwg/ipamclaims v0.5.0-alpha h1:b3iHeks/KTzhG2dNanaUZcFEJwJbYBZY16jxCaVv9i8=
 github.com/k8snetworkplumbingwg/ipamclaims v0.5.0-alpha/go.mod h1:MGaMX1tJ7MlHDee4/xmqp3guQh+eDiuCLAauqD9K11Q=
-github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.7.5 h1:CELpSMPSyicFBaVsxROmfrWlu9yr3Dduk+y7vGrIsx8=
-github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.7.5/go.mod h1:CM7HAH5PNuIsqjMN0fGc1ydM74Uj+0VZFhob620nklw=
+github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.7.7 h1:z4P744DR+PIpkjwXSEc6TvN3L6LVzmUquFgmNm8wSUc=
+github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.7.7/go.mod h1:CM7HAH5PNuIsqjMN0fGc1ydM74Uj+0VZFhob620nklw=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.17.11 h1:In6xLpyWOi1+C7tXUUWv2ot1QvBjxevKAaI6IXrJmUc=

--- a/vendor/github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1/types.go
+++ b/vendor/github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1/types.go
@@ -2,9 +2,9 @@ package v1
 
 import (
 	"encoding/json"
-	"errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"net"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // +genclient
@@ -177,9 +177,6 @@ func (nse *NetworkSelectionElement) UnmarshalJSON(b []byte) error {
 	if err := json.Unmarshal(b, &netSelectionElement); err != nil {
 		return err
 	}
-	if len(netSelectionElement.IPRequest) > 0 && netSelectionElement.IPAMClaimReference != "" {
-		return TooManyIPSources
-	}
 	*nse = NetworkSelectionElement(netSelectionElement)
 	return nil
 }
@@ -198,5 +195,3 @@ type NoK8sNetworkError struct {
 }
 
 func (e *NoK8sNetworkError) Error() string { return string(e.Message) }
-
-var TooManyIPSources = errors.New("cannot provide a static IP and a reference of an IPAM claim in the same network selection element")

--- a/vendor/github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/utils/net-attach-def.go
+++ b/vendor/github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/utils/net-attach-def.go
@@ -207,6 +207,12 @@ func CreateNetworkStatuses(r cnitypes.Result, networkName string, defaultNetwork
 		}
 	}
 
+	var defaultNetworkStatus *v1.NetworkStatus
+	if len(networkStatuses) > 0 {
+		// Set the default network status to the last network status.
+		defaultNetworkStatus = networkStatuses[len(networkStatuses)-1]
+	}
+
 	// Map IPs to network interface based on index
 	for _, ipConfig := range result.IPs {
 		if ipConfig.Interface != nil {
@@ -214,6 +220,12 @@ func CreateNetworkStatuses(r cnitypes.Result, networkName string, defaultNetwork
 			if newIndex, ok := indexMap[originalIndex]; ok {
 				ns := networkStatuses[newIndex]
 				ns.IPs = append(ns.IPs, ipConfig.Address.IP.String())
+			}
+		} else {
+			// If the IPs don't specify the interface assign the IP to the default network status. This keeps the behaviour
+			// consistent with previous multus versions.
+			if defaultNetworkStatus != nil {
+				defaultNetworkStatus.IPs = append(defaultNetworkStatus.IPs, ipConfig.Address.IP.String())
 			}
 		}
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -98,7 +98,7 @@ github.com/json-iterator/go
 # github.com/k8snetworkplumbingwg/ipamclaims v0.5.0-alpha
 ## explicit; go 1.23.0
 github.com/k8snetworkplumbingwg/ipamclaims/pkg/crd/ipamclaims/v1alpha1
-# github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.7.5
+# github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.7.7
 ## explicit; go 1.21
 github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io
 github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is bumping nad-client to v1.7.7 as ipam-extentions needs to align with new multus-default-network logic.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

