### PR TITLE
fix(manager): Improve upgrade behaviour

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -28,7 +28,7 @@ spec:
   selector:
     matchLabels:
       control-plane: manager
-  replicas: 1
+  replicas: 2
   template:
     metadata:
       annotations:

--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -207,7 +207,7 @@ metadata:
   name: kubevirt-ipam-controller-manager
   namespace: kubevirt-ipam-controller-system
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app: ipam-virt-workloads


### PR DESCRIPTION
**What this PR does / why we need it**:
During kubernetes upgrades the manager can loss the lease of the leader election and kubevirt webhook will fail, increasing to 2 the other replica can take over on those scenarios reducing the changes to have webhook errors at kubevirt.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Increase manager replicas to 2
```

