### PR TITLE
e2e: use Eventually for IP assertions to avoid race condition

### DIFF
--- a/test/env/matcher.go
+++ b/test/env/matcher.go
@@ -100,3 +100,12 @@ func ContainConditionVMIReady() gomegatypes.GomegaMatcher {
 			HaveField("Status", corev1.ConditionTrue),
 		)))
 }
+
+// BeReadyWithIPsAtInterface checks that the VMI is ready AND has IPs assigned at the specified interface.
+// This is a composite matcher that combines readiness and IP assignment verification.
+func BeReadyWithIPsAtInterface(interfaceName string, ipsMatcher gomegatypes.GomegaMatcher) gomegatypes.GomegaMatcher {
+	return SatisfyAll(
+		ContainConditionVMIReady(),
+		MatchIPsAtInterfaceByName(interfaceName, ipsMatcher),
+	)
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
In the e2e tests there is a hidden assumption that once the VMI is in Ready=true condition then the status.interface.ipAddress is set. This is not guaranteed, causing a [flake](https://github.com/kubevirt/cluster-network-addons-operator/actions/runs/18906135336/job/53964765741?pr=2440).
This PR adds Eventually with 30s timeout to wait for IPs to appear.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```

