### PR TITLE
make, linter target: Fix make linter targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,13 +85,13 @@ test-e2e: ginkgo virtctl
 	cd test/e2e && \
 	$(GINKGO) -p -v --timeout=${E2E_TEST_TIMEOUT} --junit-report=$${REPORT_PATH}/test-e2e.junit.xml ${E2E_TEST_ARGS}
 
+golangci_lint_args = --timeout 10m --verbose
 .PHONY: lint
-lint: golangci-lint ## Run golangci-lint linter & yamllint
-	$(GOLANGCI_LINT) run
-
+lint: golangci-lint ## Run golangci-lint linter
+	$(GOLANGCI_LINT) run $(golangci_lint_args)
 .PHONY: lint-fix
 lint-fix: golangci-lint ## Run golangci-lint linter and perform fixes
-	$(GOLANGCI_LINT) run --fix
+	$(GOLANGCI_LINT) run --fix $(golangci_lint_args)
 
 ##@ Build
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Currently its impossible to work with the project linter locally because it use old golandci-lint version (v1.63.4).
When the binary is missing the project Makefile installs it, but fail with the following error:
```
$ make lint
Downloading github.com/golangci/golangci-lint/cmd/golangci-lint@v1.63.4
go: downloading github.com/tdakkota/asciicheck v0.3.0
../../../.golang/go/pkg/mod/github.com/golangci/golangci-lint@v1.63.4/pkg/golinters/asciicheck/asciicheck.go:4:2: reading github.com/tdakkota/asciicheck/go.mod at revision v0.3.0: git ls-remote -q origin in /home/omergi/.golang/go/pkg/mod/cache/vcs/e91413ff76cb95901df8e2d834855d07c617befa58b5014bc6cd6fd1148034dd: exit status 128:
        ERROR: Repository not found.
        fatal: Could not read from remote repository.

        Please make sure you have the correct access rights
        and the repository exists.
make: *** [Makefile:197: /home/omergi/workspace/github.com/ipam-extensions/bin/golangci-lint-v1.63.4] Error 1
```

This PR bumps the linter version to the same version CI use v2.0.2.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

