### PR TITLE
tls: Rename TLS groups preferences flag

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -74,7 +74,7 @@ func main() {
 	var defaultNetworkNadNamespace string
 	var tlsMinVersionRaw string
 	var tlsCipherSuitesRaw string
-	var tlsCurvePreferencesRaw string
+	var tlsGroupPreferencesRaw string
 
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false, "Enable leader election for controller manager. "+
@@ -93,9 +93,9 @@ Supported values are tls package constants names (e.g. TLS_AES_128_GCM_SHA256)
 please see https://pkg.go.dev/crypto/tls#pkg-constants.
 When 'min-tls-version' is 'VersionTLS13', cipher suites are selected by the runtime.`,
 	)
-	flag.StringVar(&tlsCurvePreferencesRaw, "tls-curve-preferences", "",
-		`Comma-separated list of TLS curve preference names.
-Supported values are tls package constants names (e.g. CurveP256)
+	flag.StringVar(&tlsGroupPreferencesRaw, "tls-group-preferences", "",
+		`Comma-separated list of TLS group preference names.
+Supported values are tls package constants names (e.g. X25519MLKEM768, CurveP256)
 please see https://pkg.go.dev/crypto/tls#CurveID`,
 	)
 
@@ -117,7 +117,7 @@ please see https://pkg.go.dev/crypto/tls#CurveID`,
 	flagsTLSOpts, err := config.ParseTLSOptions(
 		tlsMinVersionRaw,
 		tlsCipherSuitesRaw,
-		tlsCurvePreferencesRaw,
+		tlsGroupPreferencesRaw,
 		setupLog.Info,
 	)
 	if err != nil {

--- a/pkg/config/tls.go
+++ b/pkg/config/tls.go
@@ -33,7 +33,7 @@ var tlsVersionByName = map[string]uint16{
 	"VersionTLS11": tls.VersionTLS11,
 	"VersionTLS10": tls.VersionTLS10,
 }
-var tlsCurveIDByName = map[string]tls.CurveID{
+var tlsGroupIDByName = map[string]tls.CurveID{
 	"X25519":         tls.X25519,
 	"CurveP256":      tls.CurveP256,
 	"CurveP384":      tls.CurveP384,
@@ -55,7 +55,7 @@ func init() {
 func ParseTLSOptions(
 	tlsMinVersionRaw string,
 	tlsCipherSuitesRaw string,
-	tlsCurvePreferencesRaw string,
+	tlsGroupPreferencesRaw string,
 	logger func(string, ...any),
 ) (
 	func(*tls.Config),
@@ -75,8 +75,8 @@ func ParseTLSOptions(
 		logger("WARNING: insecure TLS cipher suite is being used:", tls.CipherSuiteName(cipherSuiteID))
 	}
 
-	curvePreferenceNames := parseStringSlice(tlsCurvePreferencesRaw)
-	curvePreferenceIDs, err := toCurveIDs(curvePreferenceNames)
+	groupPreferenceNames := parseStringSlice(tlsGroupPreferencesRaw)
+	groupPreferenceIDs, err := toGroupIDs(groupPreferenceNames)
 	if err != nil {
 		return nil, err
 	}
@@ -88,8 +88,9 @@ func ParseTLSOptions(
 		if len(cipherSuiteIDs) > 0 {
 			c.CipherSuites = cipherSuiteIDs
 		}
-		if len(curvePreferenceIDs) > 0 {
-			c.CurvePreferences = curvePreferenceIDs
+		if len(groupPreferenceIDs) > 0 {
+			// although the legacy name, CurvePreferences supports non elliptic-curve key-exchange mechanisms.
+			c.CurvePreferences = groupPreferenceIDs
 		}
 	}
 	return tlsOpts, nil
@@ -114,10 +115,10 @@ func toCipherSuiteIDs(cipherSuiteNames []string) ([]uint16, error) {
 	return ids, nil
 }
 
-func toCurveIDs(curveNames []string) ([]tls.CurveID, error) {
-	ids, err := getValuesByKeys(tlsCurveIDByName, curveNames)
+func toGroupIDs(groupNames []string) ([]tls.CurveID, error) {
+	ids, err := getValuesByKeys(tlsGroupIDByName, groupNames)
 	if err != nil {
-		return nil, fmt.Errorf("unable to find curve preference IDs: %w", err)
+		return nil, fmt.Errorf("unable to find group preference IDs: %w", err)
 	}
 	return ids, nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The flag 'tls-curve-preferences' controls which key-exchange algorithm group
to use for TLS session. Its name follows the legacy  'curves' terminology.
Initially the TLS parameter for the key-exchange algorithm groups used to
support elliptic curves only; a specific groups of algorithms.
In newer versions (1.3) it was extended to support other groups
(non-elliptic curve) [1] [2].
Although Go crypto use the same field for non-elliptic curve groups [3].

Rename the flag to follow the correct TLS terminology.

[1] https://www.iana.org/assignments/tls-parameters/tls-parameters.xml#tls-parameters-8 (see "Renamed from" note)
[2] https://www.rfc-editor.org/rfc/rfc8446.html#section-4.2.7
[3] https://pkg.go.dev/crypto/tls@go1.25.9#CurveID

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

